### PR TITLE
Make plugin installable: fix plugin.json schema and add marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "sui-pilot",
+  "owner": {
+    "name": "nikos-terzo"
+  },
+  "plugins": [
+    {
+      "name": "sui-pilot",
+      "source": "./",
+      "description": "Claude Code plugin for full Sui Stack development (nikos-terzo fork with schema fixes)"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,14 +13,6 @@
     "language-server",
     "diagnostics"
   ],
-  "commands": [
-    "../commands/sui-pilot.md",
-    "../commands/move-code-quality.md",
-    "../commands/move-code-review.md",
-    "../commands/move-tests.md"
-  ],
-  "skills": "../skills/",
-  "agents": ["../agents/sui-pilot-agent.md"],
   "mcpServers": {
     "move-lsp": {
       "command": "node",


### PR DESCRIPTION
Removes the invalid commands/agents/skills fields from plugin.json (Claude Code expects auto-discovery from standard dirs, not arrays of file paths with ../ prefixes). Adds a marketplace.json so the repo is a self-contained, one-line install target.