### PR TITLE
Default to foreground when launching sui-pilot-agent

### DIFF
--- a/commands/sui-pilot.md
+++ b/commands/sui-pilot.md
@@ -27,4 +27,16 @@ The agent follows a doc-first approach:
 3. Enforces Sui Move best practices
 4. Runs quality and security review skills
 
+## Invocation
+
+Launch the sui-pilot-agent in the **foreground** unless the user's permission
+mode auto-approves tool calls (Auto, acceptEdits, or
+`--dangerously-skip-permissions`). Rationale: the agent and the skills it
+chains to call Write, Edit, MultiEdit, and Bash; background subagents can't
+surface permission prompts, so in interactive modes these tool calls silently
+auto-deny.
+
+In auto-approving modes, foreground vs background doesn't matter — pick
+whichever fits the work.
+
 You will now be connected to the sui-pilot-agent for specialized Sui Move development assistance.


### PR DESCRIPTION
## Summary

- When the `/sui-pilot` command routes to `sui-pilot-agent`, instruct the main session to launch the subagent in the foreground by default.
- Background subagents have no interactive surface, so permission prompts for Write/Edit/MultiEdit/Bash silently auto-deny. The agent (and the skills it chains to) can't do its job in that state under default permission mode.
- Skipped when the user's permission mode already auto-approves tool calls (Auto, acceptEdits, `--dangerously-skip-permissions`) — foreground vs background is irrelevant there.

## Why

Running the agent silently fails under the default permission mode: the user sees no prompts, the agent reports denials it can't explain, and the failure looks like a plugin bug. This is a one-paragraph addition to `commands/sui-pilot.md` that makes the default path work everywhere without constraining users who've already opted into auto-approval.

## Test plan

- [ ] Run `/sui-pilot` in default permission mode → agent launches in foreground, Write/Edit/Bash prompts surface to the user.
- [ ] Run `/sui-pilot` under `--dangerously-skip-permissions` → agent may run in background, no prompts needed.
- [ ] Run `/sui-pilot` in Auto / acceptEdits modes → either foreground or background works; prompts auto-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)