### PR TITLE
docs(sui-pilot): note that doc index is subagent-scoped by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,20 @@ sui-pilot is designed for Claude Code. Some capabilities are environment-specifi
 - **macOS and Linux only**: Windows is not officially supported.
 - **Documentation lag**: Bundled docs are point-in-time snapshots. Run `./sync-docs.sh` to update.
 
+### Doc index is subagent-scoped by default
+
+The pipe-delimited doc index lives inside `agents/sui-pilot-agent.md` and is loaded into context only when something invokes the `sui-pilot-agent` subagent. The bundled skills (`/sui-pilot`, `/move-pr-review`, `/move-code-review`, `/move-code-quality`, `/move-tests`, `/oz-math`) all dispatch the subagent, so they get the index for free.
+
+**Free-form Claude Code chat does not.** If you ask a Sui/Move/Walrus/Seal question without invoking one of the sui-pilot skills, Claude falls back to its training memory — which is stale. You may see deprecated Move 1.x syntax, removed `SuiClient` imports, missing `network` parameters on the new TS SDK 2.0 clients, and similar drift.
+
+**Workaround for users whose work is predominantly Sui-related:** add this line to your `~/.claude/CLAUDE.md` so the doc index loads in every session:
+
+```markdown
+@~/.claude/sui-pilot/agents/sui-pilot-agent.md
+```
+
+The trade-off is a fixed ≈16 KB of context per session (vs. zero when only skills are invoked). For occasional Sui work, prefer running the skills on demand instead.
+
 ---
 
 ## Contributing / local development


### PR DESCRIPTION
## Summary
- Adds a new **Doc index is subagent-scoped by default** subsection inside the existing `## Limitations` section of the README, after the "Other limitations" bullet list and before the trailing divider.
- Explains *why* free-form Claude Code chat may produce stale Sui/Move/TS-SDK output even with sui-pilot installed: the doc index lives inside the `sui-pilot-agent` subagent system prompt, and is only loaded when something dispatches that subagent (the bundled `/sui-pilot`, `/move-pr-review`, `/move-code-review`, `/move-code-quality`, `/move-tests`, `/oz-math` skills do; ad-hoc chat does not).
- Documents the opt-in workaround: `@~/.claude/sui-pilot/agents/sui-pilot-agent.md` in the user's `~/.claude/CLAUDE.md`. Calls out the ~16 KB constant context cost so users can decide based on how Sui-heavy their work is.

## Test plan
- [x] `grep -n "subagent-scoped" README.md` returns exactly one hit.
- [x] Render the README on GitHub and confirm the new `### Doc index is subagent-scoped by default` subsection sits inside the `## Limitations` section, above the `---` divider that precedes `## Contributing / local development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)