### PR TITLE
docs: fix broken suiup install link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ rm -rf ~/.claude/plugins/sui-pilot
 
 | Component            | Version      | Notes                                                                  |
 | -------------------- | ------------ | ---------------------------------------------------------------------- |
-| suiup                | Latest       | `curl -fsSL https://sui.io/install.sh \| sh`                           |
+| suiup                | Latest       | `curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh \| sh` |
 | sui + move-analyzer  | Same version | **Must match versions** — install both via suiup                       |
 | Claude Code          | Latest       | Plugin host environment                                                |
 | Node.js              | 18+          | Used to run the bundled MCP server (usually already present)           |
@@ -111,7 +111,7 @@ rm -rf ~/.claude/plugins/sui-pilot
 
 ```bash
 # Install suiup
-curl -fsSL https://sui.io/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"  # Add to shell profile
 
 # Install sui and move-analyzer (versions must match!)


### PR DESCRIPTION
## Summary

- The README's Requirements section was telling users to install suiup from `https://sui.io/install.sh`, which isn't live yet — `curl` returns 404.
- Replace both occurrences (table row + code block) with the canonical Mystenlabs install script: `curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | sh`.
- When the `sui.io/install.sh` redirect ships, a follow-up can switch back.

Reported by Stefan Stanciulescu

## Test plan

- [x] `grep -n "sui.io/install.sh" README.md` returns no matches.
- [x] `curl -sSfL -o /dev/null -w "%{http_code}\n" https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh` returns `200`.
- [ ] Manual: copy-paste the new command from the Requirements section into a fresh shell and confirm suiup installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)