### PR TITLE
docs: route Nautilus topics in agent + plugin CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Always search and read these docs before writing code for these ecosystems.
 | Walrus storage, blobs, Sites, operators | `.walrus-docs/` | 84 |
 | Seal secrets, encryption, key servers, access control | `.seal-docs/` | 14 |
 | TypeScript SDK, dapp-kit, React hooks, kiosk, payment-kit | `.ts-sdk-docs/` | 115 |
-| Nautilus off-chain compute: TEE enclaves, attestation, PCRs, on-chain verification | `.sui-docs/sui-stack/nautilus/` | 7 |
+| Nautilus off-chain compute, TEE enclaves, attestation, PCRs, on-chain verification | `.sui-docs/sui-stack/nautilus/` | 7 |
 
 ## Usage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,12 @@ Always search and read these docs before writing code for these ecosystems.
 | Walrus storage, blobs, Sites, operators | `.walrus-docs/` | 84 |
 | Seal secrets, encryption, key servers, access control | `.seal-docs/` | 14 |
 | TypeScript SDK, dapp-kit, React hooks, kiosk, payment-kit | `.ts-sdk-docs/` | 115 |
+| Nautilus off-chain compute: TEE enclaves, attestation, PCRs, on-chain verification | `.sui-docs/sui-stack/nautilus/` | 7 |
 
 ## Usage
 
 1. The `sui-pilot-agent` subagent auto-loads the slim doc-first directive in `agents/sui-pilot-agent.md`. Commands routing through it (`/sui-pilot`, `/move-pr-review`, etc.) are docs-first out of the box.
-2. If you are developing on this repo directly, use `Glob` and `Grep` against the appropriate `.<source>-docs/` directory for your topic. When unsure which source, search all five.
+2. If you are developing on this repo directly, use `Glob` and `Grep` against the appropriate `.<source>-docs/` directory for your topic. When unsure which source, search across all corpora.
 3. Walrus and Seal build on Sui — Sui docs may also be relevant. For Move language questions (syntax, idioms, language semantics), prefer `.move-book-docs/` first.
 4. `.move-book-docs/packages/` holds Move source examples referenced from the Move Book prose (`file=` directives) — read them when an example would clarify a pattern.
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -39,6 +39,7 @@ Route by topic — the search root is `${CLAUDE_PLUGIN_ROOT}/.<source>-docs/`:
 | Walrus storage: blobs, Sites, operators, HTTP API | `.walrus-docs/` |
 | Seal secrets: encryption, key servers, access policies | `.seal-docs/` |
 | TypeScript SDK: clients, dapp-kit, kiosk, payment-kit, SDK 2.0 | `.ts-sdk-docs/` |
+| Nautilus off-chain compute: TEE enclaves, attestation, PCRs, on-chain verification | `.sui-docs/sui-stack/nautilus/` |
 
 Use `Glob` to find files by name and `Grep` to search content — never request a precomputed index. Walrus and Seal build on Sui, so cross-reference `.sui-docs/` when an answer spans layers. `.move-book-docs/packages/` holds Move source examples referenced from prose via `file=` directives — open them when an example would clarify a pattern.
 


### PR DESCRIPTION
## Summary
- Add a **Nautilus** row to both routing tables (`agents/sui-pilot-agent.md` and the plugin `CLAUDE.md`) so the doc-first agent knows the 7 bundled pages under `.sui-docs/sui-stack/nautilus/` exist (TEE enclaves, attestation, PCRs, on-chain verification).
- Today the corpus ships but is unadvertised — a model asked about Nautilus has no cue that `.sui-docs/` is the right grep root and falls back to (stale) training memory.
- Also generalizes the "search all five" hint to "search across all corpora" now that the table lists a sub-corpus rather than a sixth root.

## Test plan
- [ ] Open a fresh session and ask the agent a Nautilus question (e.g. "what does PCR2 cover?") — verify it greps `.sui-docs/sui-stack/nautilus/` instead of inventing an answer.
- [ ] Confirm the routing tables in both files render correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)