### PR TITLE
feat: vendor MystenLabs/skills as auto-syncing submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule ".mysten-skills"]
+	path = .mysten-skills
+	url = git@github.com:MystenLabs/skills.git
+	branch = main
+	update = merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,15 @@ Always search and read these docs before writing code for these ecosystems.
 ```bash
 ./sync-docs.sh            # Pull latest from upstream MystenLabs repos
 ```
+
+## Vendored MystenLabs Skills
+
+`MystenLabs/skills` is vendored as a submodule at `.mysten-skills/` (declares `branch = main` and `update = merge`, so a single `git submodule update --init --recursive --remote --merge` fast-forwards it). Each upstream skill is exposed to Claude Code via a symlink `skills/<name> -> ../.mysten-skills/<name>`, so the working tree always reflects the current submodule pin without any copy step.
+
+Re-materialize symlinks (idempotent; run after the submodule moves or upstream adds/removes skills):
+
+```bash
+./scripts/sync-mysten-skills.sh
+```
+
+Local sui-pilot skills under `skills/` (real directories — `move-code-quality`, `move-code-review`, `move-pr-review`, `move-tests`, `oz-math`) take precedence; the sync script refuses to overwrite them.

--- a/scripts/sync-mysten-skills.sh
+++ b/scripts/sync-mysten-skills.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# sync-mysten-skills.sh — Materialize MystenLabs/skills as symlinks under skills/.
+#
+# The MystenLabs/skills repo is vendored as a submodule at .mysten-skills/.
+# Claude Code auto-discovers plugin skills at skills/<name>/SKILL.md, so each
+# upstream skill needs its own entry there. Symlinks let the working tree
+# always reflect whatever the submodule currently points at — no copy step.
+#
+# Idempotent. Safe to re-run after `git submodule update --remote --merge`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SRC_ROOT="${PLUGIN_ROOT}/.mysten-skills"
+DST_ROOT="${PLUGIN_ROOT}/skills"
+
+# Skills in .mysten-skills/ to skip (templates, examples, anything that
+# would pollute the active skill list).
+SKIP=(template)
+
+skip_contains() {
+  local needle="$1"
+  for s in "${SKIP[@]}"; do [[ "$s" == "$needle" ]] && return 0; done
+  return 1
+}
+
+if [[ ! -d "$SRC_ROOT" ]]; then
+  echo "ERROR: ${SRC_ROOT} not found. Run 'git submodule update --init --recursive'." >&2
+  exit 1
+fi
+
+mkdir -p "$DST_ROOT"
+
+linked=0
+skipped=0
+conflicts=0
+removed=0
+
+# 1) Create / refresh symlinks for every upstream skill with a SKILL.md.
+for src in "$SRC_ROOT"/*/; do
+  name="$(basename "$src")"
+  skip_contains "$name" && { echo "  [skip ] $name (excluded)"; ((skipped++)); continue; }
+  [[ -f "$src/SKILL.md" ]] || { echo "  [skip ] $name (no SKILL.md)"; ((skipped++)); continue; }
+
+  dst="$DST_ROOT/$name"
+  expected="../.mysten-skills/$name"
+
+  if [[ -L "$dst" ]]; then
+    actual="$(readlink "$dst")"
+    if [[ "$actual" == "$expected" ]]; then
+      echo "  [ok   ] $name"
+    else
+      ln -sfn "$expected" "$dst"
+      echo "  [retgt] $name (was: $actual)"
+    fi
+  elif [[ -e "$dst" ]]; then
+    echo "  [CONFL] $name — real dir/file at $dst; refusing to overwrite" >&2
+    ((conflicts++))
+    continue
+  else
+    ln -s "$expected" "$dst"
+    echo "  [link ] $name"
+  fi
+  ((linked++))
+done
+
+# 2) Remove stale symlinks in skills/ that point into .mysten-skills/ but whose
+#    upstream source has been deleted, renamed, or excluded.
+for dst in "$DST_ROOT"/*; do
+  [[ -L "$dst" ]] || continue
+  target="$(readlink "$dst")"
+  [[ "$target" == ../.mysten-skills/* ]] || continue
+
+  name="$(basename "$dst")"
+  if skip_contains "$name" || [[ ! -f "$SRC_ROOT/$name/SKILL.md" ]]; then
+    rm "$dst"
+    echo "  [unlnk] $name"
+    ((removed++))
+  fi
+done
+
+echo ""
+echo "==> sync-mysten-skills: linked=${linked} skipped=${skipped} removed=${removed} conflicts=${conflicts}"
+[[ $conflicts -eq 0 ]]

--- a/skills/accessing-data
+++ b/skills/accessing-data
@@ -1,0 +1,1 @@
+../.mysten-skills/accessing-data

--- a/skills/composable-move-functions
+++ b/skills/composable-move-functions
@@ -1,0 +1,1 @@
+../.mysten-skills/composable-move-functions

--- a/skills/frontend-apps
+++ b/skills/frontend-apps
@@ -1,0 +1,1 @@
+../.mysten-skills/frontend-apps

--- a/skills/generate-sui-agent-config
+++ b/skills/generate-sui-agent-config
@@ -1,0 +1,1 @@
+../.mysten-skills/generate-sui-agent-config

--- a/skills/modern-move-syntax
+++ b/skills/modern-move-syntax
@@ -1,0 +1,1 @@
+../.mysten-skills/modern-move-syntax

--- a/skills/move-unit-testing
+++ b/skills/move-unit-testing
@@ -1,0 +1,1 @@
+../.mysten-skills/move-unit-testing

--- a/skills/naming-conventions
+++ b/skills/naming-conventions
@@ -1,0 +1,1 @@
+../.mysten-skills/naming-conventions

--- a/skills/object-model
+++ b/skills/object-model
@@ -1,0 +1,1 @@
+../.mysten-skills/object-model

--- a/skills/ptbs
+++ b/skills/ptbs
@@ -1,0 +1,1 @@
+../.mysten-skills/ptbs

--- a/skills/sui-build-test
+++ b/skills/sui-build-test
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-build-test

--- a/skills/sui-cli
+++ b/skills/sui-cli
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-cli

--- a/skills/sui-client
+++ b/skills/sui-client
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-client

--- a/skills/sui-install
+++ b/skills/sui-install
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-install

--- a/skills/sui-move
+++ b/skills/sui-move
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-move

--- a/skills/sui-move-project
+++ b/skills/sui-move-project
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-move-project

--- a/skills/sui-overview
+++ b/skills/sui-overview
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-overview

--- a/skills/sui-publish
+++ b/skills/sui-publish
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-publish

--- a/skills/sui-sdks
+++ b/skills/sui-sdks
@@ -1,0 +1,1 @@
+../.mysten-skills/sui-sdks

--- a/skills/walrus-sites
+++ b/skills/walrus-sites
@@ -1,0 +1,1 @@
+../.mysten-skills/walrus-sites


### PR DESCRIPTION
## Summary
- Vendors `github.com/MystenLabs/skills` at `.mysten-skills/` via the project's standard submodule pattern (`branch = main, update = merge`), so a single `git submodule update --init --recursive --remote --merge` fast-forwards it.
- Exposes 19 upstream skills to Claude Code via relative symlinks at `skills/<name> -> ../.mysten-skills/<name>` — no copy step; the working tree always reflects the current submodule pin.
- Adds `scripts/sync-mysten-skills.sh` to (re-)materialize the symlinks idempotently when upstream adds or removes a skill. Excludes the `template/` placeholder; refuses to clobber real local sui-pilot skills (`move-code-quality`, `move-code-review`, `move-pr-review`, `move-tests`, `oz-math`).

## Test plan
- [x] `git submodule update --init --recursive --remote --merge` resolves the submodule and reports no detached-HEAD / merge errors
- [x] `./scripts/sync-mysten-skills.sh` is idempotent (second run reports `linked=19 skipped=1 removed=0 conflicts=0` with all `[ok]`)
- [x] Symlinks resolve: `head skills/sui-cli/SKILL.md` reads the upstream frontmatter
- [x] Local skills untouched: `skills/move-code-quality`, `skills/oz-math` etc. remain real directories
- [ ] Smoke-test in a fresh Claude Code session: at least one of the new upstream skills (e.g. `sui-cli`, `walrus-sites`) loads from `skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)