### PR TITLE
chore: gitignore evals/specify-*/ — /specify artifacts live in fv-lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ docs/*
 # Eval run outputs — produced by evals/run-comparison.sh, not source-controlled.
 evals/results/
 
+# Per-run /specify evaluation artifacts (HTML reports + status pages).
+# Published privately via the sui-pilot-fv-lab repo, not from sui-pilot.
+evals/specify-*/
+
 # GitHub Pages staging directory — assembled by the pages.yml workflow.
 _site/
 


### PR DESCRIPTION
## Summary

- Adds `evals/specify-*/` to `.gitignore` so per-run HTML reports + status pages from the `/specify` skill stay out of this repo.
- These explaining artifacts now live in the MystenLabs-internal companion repo [`MystenLabs/sui-pilot-fv-lab`](https://github.com/MystenLabs/sui-pilot-fv-lab), which collects the FV walkthrough plus the Aftermath AMM case study and skill-eval reports under one centralized landing page. The Pages site is access-gated by Mysten SSO.
- Move-amm-public has the same gate locally (`.specify-report.html`, `.specify-progress.json`) to prevent accidental push to the AftermathFinance upstream.

## Test plan

- [x] `git check-ignore -v evals/specify-aftermath-eval/report.html` → matched by `evals/specify-*/`
- [x] No existing tracked path collides with the new pattern (`git ls-files evals/` returns only `BASELINE.md`, `README.md`, `compare-prompt.md`, and the fixtures tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)