### PR TITLE
feat(specify): separate-package deliverable + /verify companion

### DIFF
--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -80,10 +80,12 @@ Per the plan, the target set is `public` (non-package) + `entry`. Use the regex 
    - **Exclude** the immediately-preceding `#[test_only]`, `#[test]`, or `#[allow(...)]` attribute lines from the classifier window (lookback ≤ 1 attribute block, not 200 chars).
 3. Build the target list: every `public` (excluding `public(package)`) + every `entry` (including those that are also `public`).
 4. Call `mcp__sui-prover__list_specs` with the package root.
-5. Mark each target as `verified` (already has a `#[spec(prove)]`), `pending` (no spec yet), or `partial` (has a `#[spec(skip)]` or `#[spec(focus)]` — needs upgrade).
+5. Mark each target as `verified` (carries `#[spec(prove)]` — a `focus` selector *alongside* `prove`, i.e. `#[spec(prove, focus)]`, is still `verified`; `focus` is an orthogonal debugging selector, not a partial state, though it should be stripped before commit) or `pending` (no spec yet). Mark as `partial` only a `#[spec(skip)]` (opaque axiom needing a real spec) or a **lone `#[spec(focus)]` without `prove`**.
 6. Write `.specify-progress.json` at the package root with the initial state. **Add it to `.gitignore` proactively if it's not already excluded** — the file is per-run state, not source.
 
 Report a one-line summary: "N externally-reachable functions: M verified, K pending, P partial".
+
+**Empty target set.** If the target list is empty (no `public`/`entry` functions — everything is private or `public(package)`), there is no external API to specify: write `.specify-progress.json` with `functions: {}`, emit a short report noting "no externally-reachable functions to specify", and exit cleanly — skip Phases 1.5–5's per-function work.
 
 ## Phase 1.5 — Scope decision + callee-quality probe
 
@@ -153,6 +155,17 @@ The default deliverable is a **separate sibling spec package**, not inline specs
 
    [addresses]
    <pkg>_specs = "0x0"
+   ```
+
+   **Addresses resolve through the dep — declare only the spec package's own.** The `[addresses]` block above declares *only* `<pkg>_specs`. The production package's named address (`<pkg>`) is supplied by the `local` dependency; do **not** redeclare it here (a second concrete value for `<pkg>` triggers `dep_address_conflict`). If the production package publishes its address (`published-at` / a fixed `<pkg> = "0x…"`), the dep carries that automatically. If it leaves `<pkg> = "0x0"` (unpublished), that's fine — the prover assigns it at build. A first-prove `unresolved_named_address` (failure-taxonomy) means the dep path is wrong, not that you should add `<pkg>` to the spec package's `[addresses]`. Worked shape:
+
+   ```toml
+   # production pkg's own Move.toml has:  [addresses]\n  <pkg> = "0x0"
+   # spec pkg declares ONLY its own address; <pkg> flows in via the local dep:
+   [dependencies]
+   <Pkg> = { local = "../<pkg>" }
+   [addresses]
+   <pkg>_specs = "0x0"     # NOT <pkg>
    ```
 
 2. **Announce, don't silently create.** Creating the sibling package is the documented default, so it does **not** need a per-run AskUserQuestion gate — but announce it in plain text: *"Scaffolding spec package `<pkg>_specs/` (production source stays untouched)."* In **non-interactive mode**, proceed without prompting. The production package is never modified in the default flow.
@@ -333,8 +346,8 @@ Update `.specify-progress.json` after each iteration. Schema:
     { "target": "fixed::mul_down", "file": "<pkg>_specs/sources/specify_axioms.move", "assumption": "unconstrained — no postcondition" }
   ],
   "functions": {
-    "function_id": {
-      "status": "pending" | "drafted" | "verified" | "skipped" | "needs_human" | "failed",
+    "<mod>::<fn>": {
+      "status": "pending" | "drafted" | "verified" | "skipped" | "needs_human" | "failed" | "discovery_only",
       "attempts": N,
       "last_error": "...",
       "spec_package": "<pkg>_specs",
@@ -345,7 +358,7 @@ Update `.specify-progress.json` after each iteration. Schema:
   }
 }
 ```
-`layout`, `spec_packages`, and per-function `prover_flags` / `spec_package` make resume deterministic and feed Phase 5's manifest. `trusted_axioms` accumulates every `#[spec(skip, target = …)]` for the report's disclosure section.
+Each function is keyed by its **`function_id` = `<mod>::<fn>`** — the same key form as the manifest's `source_hashes` (Phase 5.1), so progress and manifest align and resume matches reliably. `layout`, `spec_packages`, and per-function `prover_flags` / `spec_package` make resume deterministic and feed Phase 5's manifest. `trusted_axioms` accumulates every `#[spec(skip, target = …)]` for the report's disclosure section. `discovery_only` is the status set in Phase 0 step 4 when the prover binary is absent (discovery ran, no proving).
 
 ## Phase 5 — Hand off (deliverable)
 
@@ -359,17 +372,22 @@ Write `spec-context.json` next to the report. It binds the proof to the state it
 {
   "generated_at": "<ISO8601>",
   "hash_method": "bytecode" | "normalized_source",
-  "production_package": { "name": "<pkg>", "source_hashes": { "<mod>::<fn>": "<8-char>" } },
+  "production_package": { "name": "<pkg>", "source_hashes": { "<mod>::<fn>": "<16-hex>" } },
   "spec_packages": [
-    { "package": "<pkg>_specs",    "flags": [] },
-    { "package": "<pkg>_specs_bv", "flags": ["--no-bv-int-encoding"] }
+    { "name": "<pkg>_specs",    "flags": [] },
+    { "name": "<pkg>_specs_bv", "flags": ["--no-bv-int-encoding"] }
   ],
   "deps": [ { "name": "...", "rev": "...", "pinned_to_branch": false } ],
   "toolchain": { "sui_prover": "...", "sui_cli": "...", "boogie": "...", "z3": "..." }
 }
 ```
 
-Source hashes are **per-function** (minimize false-positive staleness) over compiled bytecode where available, else normalized source. Reuse `dep-pins-capture` logic for the `deps` block rather than duplicating it. Toolchain versions come from the Phase 0 `prover_capabilities` probe. **v1 is manifest-only** — capture, no preflight clone, no drift enforcement (those are roadmap v2/v3; design doc Q4).
+**Hash recipe (exact — `/verify` Phase 2a mirrors this byte-for-byte).** Hashes are **per-function**, keyed `<mod>::<fn>` (the same key form as `.specify-progress.json` `functions`). `hash_method` defaults to `normalized_source` in v1:
+
+- `normalized_source` (default): take the function's full source span — from its first attribute/`fun` line through the matching closing brace — strip line (`//`) and block (`/* */`) comments, then collapse every run of whitespace (including newlines) to a single space and trim. Hash the resulting bytes with `sha2_256` and record the **first 16 hex chars**. Comment/format reflows therefore do not register as drift; any token change does.
+- `bytecode` (opt-in, requires a build): hash the function's compiled bytecode slice from `build/<pkg>/bytecode_modules/<mod>.mv`. Closer to what the prover sees, but needs a successful `sui move build`; prefer `normalized_source` unless the user asks for bytecode binding.
+
+Reuse `dep-pins-capture` logic for the `deps` block rather than duplicating it. Toolchain versions come from the Phase 0 `prover_capabilities` probe. **v1 is manifest-only** — capture, no preflight clone, no drift enforcement (those are roadmap v2/v3; design doc Q4).
 
 ### 5.2 The report — invariant-driven, hybrid granularity (Q5 / Q1)
 
@@ -392,7 +410,7 @@ On regen, replace only content between `auto:` markers; never touch `human:` zon
 
 Invariants are named human-readable + stable slug (`INV-supply-conservation`); the source→invariant link is an explicit `// invariant: supply-conservation` marker above the `#[spec(prove)]` in the spec module (survives report regen).
 
-**Limitations section must enumerate trusted axioms (L6).** Under a "Trusted axioms — not proved" heading, list every `#[spec(skip, target = …)]` from `.specify-progress.json` `trusted_axioms[]` (target + file + the assumption in prose) **and** every hand-written `prelude_extra.bpl` axiom if one was used. These are holes in the verification — a wrong axiom makes the proof vacuous, so they're the auditor's first read.
+**Limitations section must enumerate trusted axioms (L6).** Under a "Trusted axioms — not proved" heading, list every `#[spec(skip, target = …)]` from `.specify-progress.json` `trusted_axioms[]` (target + file + the assumption in prose) **and** every hand-written Boogie axiom from any `extra_bpl` file used (wired via the `#[spec_only(extra_bpl = b"…")]` attribute — see `references/spec-patterns.md` §8.1). These are holes in the verification — a wrong axiom makes the proof vacuous, so they're the auditor's first read.
 
 **Package `index.html`:** package overview + top-level claim; cross-module invariants with proof-obligation mapping (which spec in which module discharges which obligation); coverage matrix (module × invariant, every externally-reachable fn marked specified / deliberately-skipped / known-gap *with a reason* — negative space is first-class, L9); per-module summaries with links; the manifest's toolchain + dep pins.
 
@@ -417,7 +435,7 @@ Any run starts at Phase 0 → Phase 1, then loads `.specify-progress.json` and s
 
 - **Never modify the production package in the default flow.** No `#[spec_only]`, no prover dependency, no marker blocks in the production source; no edits to the production `Move.toml`. Specs go in the sibling `<pkg>_specs/` package, which the skill owns and may create/edit freely. The only exception is the explicit `--inline` opt-out, which writes marker blocks into the production source.
 - **Never auto-edit the user's production `Move.toml`.** Surface setup issues (explicit `Sui`/`MoveStdlib` deps, edition) and let the user fix them. The skill *does* author the spec package's own `Move.toml` (Phase 3.5) — that file is a generated deliverable, not the user's.
-- **Trusted axioms are disclosed, never hidden.** Every `#[spec(skip, target = …)]` and every `prelude_extra.bpl` axiom must land in the report's "Trusted axioms — not proved" section. An undisclosed axiom is a silent hole in the verification.
+- **Trusted axioms are disclosed, never hidden.** Every `#[spec(skip, target = …)]` and every `extra_bpl` Boogie axiom must land in the report's "Trusted axioms — not proved" section. An undisclosed axiom is a silent hole in the verification.
 - **Never spec a `public(package)` function.** The user's intent (per the plan) is external-API specs only.
 - **Never emit legacy MSL syntax.** No `aborts_if`, no `pragma`, no free `axiom`. See `references/spec-patterns.md` for the modern equivalents.
 - **Never duplicate a `#[spec(...)]` for the same function.** Idempotency via the marker block.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: specify
-description: "Walks the user through writing `#[spec(prove)]` formal specifications for every externally reachable function (`public` non-package + `entry`) in their Sui Move package, drives sui-prover via the sui-prover-mcp, and iterates on failures using a documented taxonomy. Use this skill when the user invokes `/specify`, asks to 'add formal verification', 'write prover specs', 'verify this package with sui-prover', or wants to harden a Move package before mainnet deploy. Skip for `public(package)` or private functions (out of scope), or when sui-prover isn't installed. Complements /move-code-review (SEC-* findings indicate where specs matter most) and /move-tests (specs are static guarantees, tests are dynamic samples)."
+description: "Walks the user through writing `#[spec(prove)]` formal specifications for every externally reachable function (`public` non-package + `entry`) in their Sui Move package. Emits the specs into a separate sibling `<pkg>_specs/` package (keeping production source pristine), drives sui-prover via the sui-prover-mcp, and produces an invariant-driven HTML report plus a `spec-context.json` reproducibility manifest. Use this skill when the user invokes `/specify`, asks to 'add formal verification', 'write prover specs', 'verify this package with sui-prover', or wants to harden a Move package before mainnet deploy. Skip for `public(package)` or private functions (out of scope), or when sui-prover isn't installed. Complements /move-code-review (SEC-* findings indicate where specs matter most) and /move-tests (specs are static guarantees, tests are dynamic samples)."
 ---
 
 # Specify — formal specifications for Sui Move
 
 > **Doc-First Requirement.** Read `.sui-prover-docs/` before drafting any spec. The Sui Prover spec language is **not** the legacy Move Prover MSL — it uses `#[spec(prove)]`, `requires`, `ensures`, `asserts` (positive abort form), and the macros `clone!`, `forall!`, `exists!`, `invariant!`. It does NOT use `aborts_if`, `pragma`, `apply`, `assume`, or free `axiom`. Verify any construct against `.sui-prover-docs/guide/spec-reference.md` before emitting it.
+
+## Deliverable shape (read first)
+
+`/specify` ships **three artifacts**, not one. This is the load-bearing architectural decision (`docs/specify-deliverable-design.html`, learning L1, validated against `~/workspace/integer-library`):
+
+1. **The production package — left pristine.** No `#[spec_only]`, no prover dependency, no marker blocks. Verification scaffolding never touches deployed source.
+2. **One or more spec packages.** A sibling `<pkg>_specs/` package holds `#[spec(prove, target = <pkg>::<mod>::<fn>)]` twins, one `<mod>_specs.move` per source module. A function that needs a custom prover invocation (e.g. `--no-bv-int-encoding` for bit-exact semantics) goes in a *second* package `<pkg>_specs_bv/` (Phase 4.6).
+3. **The report + manifest.** A self-contained HTML report (invariant-driven, per Phase 5) plus `spec-context.json` binding each spec to its source state, dep pins, toolchain versions, and per-package prover flags.
+
+The legacy inline layout (specs in the production `.move` between markers) is now **opt-in only** via `--inline`, for single-module throwaway packages where a sibling package is overkill. Default is always the separate package.
 
 ## Non-interactive (eval) mode
 
@@ -119,6 +129,38 @@ Order pending functions:
 - "Pick one to start with" (offer the top 5 by priority)
 - "Pick a subset" (offer to filter by module or by mutation risk)
 
+## Phase 3.5 — Scaffold the spec package (default layout)
+
+The default deliverable is a **separate sibling spec package**, not inline specs (see "Deliverable shape" above; design doc L1). Scaffold it once, before the per-function loop.
+
+1. **Locate / create `<pkg>_specs/`.** Resolve the production package name from `[package].name` in `Move.toml`. The spec package lives as a sibling directory `<pkg>_specs/` (snake-cased), with this layout:
+
+   ```
+   <pkg>_specs/
+     Move.toml          # name = "<Pkg>Specs", edition = "2024.beta", dep on the production pkg
+     sources/           # one <mod>_specs.move per source module
+   ```
+
+   `Move.toml` template — depend on the production package by relative path, declare the spec address:
+
+   ```toml
+   [package]
+   name = "<Pkg>Specs"
+   edition = "2024.beta"
+
+   [dependencies]
+   <Pkg> = { local = "../<pkg>" }
+
+   [addresses]
+   <pkg>_specs = "0x0"
+   ```
+
+2. **Announce, don't silently create.** Creating the sibling package is the documented default, so it does **not** need a per-run AskUserQuestion gate — but announce it in plain text: *"Scaffolding spec package `<pkg>_specs/` (production source stays untouched)."* In **non-interactive mode**, proceed without prompting. The production package is never modified in the default flow.
+
+3. **`--inline` opt-out.** If the user passed `--inline` (or the package is a single trivial module and the user opted in at Phase 1.5), skip scaffolding and use the legacy in-source marker-block layout (Phase 4.5 "Inline fallback"). Record the chosen layout in `.specify-progress.json` under `layout: "package" | "inline"` so resume is deterministic.
+
+4. **Second package for custom prover configs is lazy.** Do *not* create `<pkg>_specs_bv/` up front. It's created on demand in Phase 4.6 only when a spec is found to need a non-default prover invocation. Most packages never need it.
+
 ## Phase 4 — Per-function loop
 
 For each pending function (sequentially — parallelism would race AskUserQuestion):
@@ -139,28 +181,44 @@ Present a compact fact sheet to the user *inside the AskUserQuestion description
 
 **One batched call** with up to 4 sub-questions, each with 3-4 options + Other. Concrete defaults so the user can accept fast:
 
-1. **Preconditions (`requires`)**: "none / parameter range check (suggested: `x.to_int().add(y.to_int()).lte(MAX_U64)`) / state precondition / Other"
-2. **Postconditions (`ensures`)**: "none / functional result (suggested: `result == x + y`) / state-after-call relation / Other"
-3. **Abort conditions (`asserts`)**: present the detected `assert!` mirrors — "use all detected mirrors / use a subset / replace with custom / none"
+1. **Abort conditions (`asserts`)** — *ask first; for math/arithmetic kernels the abort contract is the security property* (L2). Present the detected `assert!` mirrors plus any implicit abort paths (div-by-zero, shift-out-of-range, overflow in non-wrapping fns): "use all detected mirrors / use a subset / replace with custom / does not abort". The answer becomes both an `asserts(...)` in the spec **and** the report's required "Abort conditions" line (Phase 5).
+2. **Postconditions (`ensures`)** — offer two tiers, recommend the stronger:
+   - **Defining-property (recommended, L4)**: the algebraic property that *defines* the result independent of the formula. E.g. floor division: `result*d <= p < (result+1)*d`; `div_mod`: `p*d + r == num && r < d`. Strictly stronger than recomputation — a wrong mental model can't pass against a wrong implementation.
+   - **Functional result**: `result == <recompute the formula>` (suggested: `result == x + y`). The weakest useful spec; offer only when no defining property exists.
+   - Plus "state-after-call relation / none / Other".
+3. **Preconditions (`requires`)**: "none / parameter range check (suggested: `x.to_int().add(y.to_int()).lte(MAX_U64)`) / state precondition / Other"
 4. **Invariants**: "none needed / loop invariant / type invariant / ghost-state invariant / Other"
+
+For functions over a **custom numeric type** (a wrapper struct over an integer field — signed ints, fixed-point), the postcondition should be expressed in the `Integer` math domain via the type's `to_int` model (L3) — see `references/spec-patterns.md` §6 and Phase 4.3.
 
 ### 4.3 Draft (LLM)
 
-Render a `#[spec(prove)]` twin function in the canonical shape (see `references/spec-patterns.md` §2):
+**Emit the math-domain model first (L3).** If the target operates on a custom numeric type (a `struct` wrapping an integer field — signed ints, fixed-point), and the spec module does not yet contain the model, emit it once at the top of the `<mod>_specs.move` file before any spec: a `to_int` conversion into `std::integer::Integer`, a range predicate (`is_<type>`), any helper ops (`int_div_trunc`, `int_abs`, …), and `use fun` aliases so specs read like the math. See `references/spec-patterns.md` §6 for the full template. This is what makes signed-int / fixed-point specs tractable — without it they drown in two's-complement bit-fiddling.
+
+**Render the twin in the separate-package shape (default, L1).** The spec lives in `<pkg>_specs/sources/<mod>_specs.move` and references the production function by `target =`:
 
 ```move
-#[spec(prove)]
-fun <name>_spec(<params>): <return_type> {
+module <pkg>_specs::<mod>_specs;
+
+use <pkg>::<mod>::{<fn>, /* types used in the signature */};
+
+#[spec_only]
+use prover::prover::{ensures, asserts, requires, clone};
+
+#[spec(prove, target = <fn>)]
+public fun <fn>_spec(<params>): <return_type> {
     requires(<preconditions>);
     let __old = clone!(<mutable_state>);     // only if state mutation detected
-    asserts(<abort_condition>);              // one per detected mirror
-    let <r> = <name>(<args>);
-    ensures(<postcondition>);
+    asserts(<abort_condition>);              // one per detected mirror + implicit paths
+    let <r> = <fn>(<args>);                   // must call the target
+    ensures(<defining_property_postcondition>);
     <r>
 }
 ```
 
-Imports go in a `#[spec_only]` block at the bottom of the file, deduplicated against what's already there.
+The `target = <fn>` attribute binds the spec to the imported production function; the spec body **must call** the target (see failure-taxonomy `spec_target_body_no_call`). Imports of the production functions/types go in a plain `use <pkg>::<mod>::{...}` block; only the `prover::*` imports get `#[spec_only]`.
+
+**Inline shape (`--inline` opt-out only).** When the user chose the inline layout, render the legacy in-source twin (no `target =`, spec named `<fn>_spec`, written between markers in the production `.move`) per `references/spec-patterns.md` §2. Never use the inline shape in the default flow.
 
 ### 4.4 Review (AskUserQuestion)
 
@@ -171,27 +229,28 @@ Show the drafted spec inline. Single question:
 
 ### 4.5 Persist (deterministic)
 
-Write the spec at the bottom of the same `.move` file, between markers:
+**Default — separate package (L1).** Write the twin into `<pkg>_specs/sources/<mod>_specs.move` (one spec module per source module). If the file doesn't exist yet, create it with the module header, the `use <pkg>::<mod>::{...}` production imports, the `#[spec_only] use prover::prover::{...}` block, and the math-domain model (Phase 4.3, if applicable). The production package is **never touched**.
 
 ```move
-// === sui-pilot specify: generated specs (do not edit between markers) ===
+module <pkg>_specs::<mod>_specs;
+
+use <pkg>::<mod>::{<fn>, /* types */};
 
 #[spec_only]
-use prover::prover::{requires, ensures, asserts, clone};
-// (additional imports as needed)
+use prover::prover::{ensures, asserts, requires, clone};
 
-#[spec(prove)]
-fun <name>_spec(...) { ... }
+// (math-domain model here, if the module specs a custom numeric type — §6)
 
-// === end sui-pilot specify ===
+#[spec(prove, target = <fn>)]
+public fun <fn>_spec(<params>): <return_type> { ... }
 ```
 
-**Idempotency rule.** If the marker block already exists, splice the new spec into it. Never duplicate a `#[spec(...)]` for the same function — if one exists, ask the user (4.4-style) whether to refine or overwrite.
+**Idempotency rule.** Key on the `target = <fn>` attribute. If a spec for that target already exists in the module, never duplicate it — ask the user (4.4-style) whether to refine or overwrite. Splice new imports into the existing `use` blocks, deduplicated.
 
-**Sidecar axiom file** (recommended when the package has stub callees, large axiom counts, or any cross-package targets). Instead of inlining axiom declarations next to every spec block, create `sources/specify_axioms.move` inside the target package:
+**Sidecar axiom file** (when the production package has stub callees — every dep body is `abort 0`). Axioms model the stubbed callees of the production package, so they live in the spec package as `<pkg>_specs/sources/specify_axioms.move`:
 
 ```move
-module <pkg>::specify_axioms;
+module <pkg>_specs::specify_axioms;
 
 #[spec_only]
 use prover::prover::{fresh};
@@ -207,13 +266,33 @@ fun mul_down_spec(_a: u256, _b: u256): u256 { fresh() }
 fun ln_spec(_x: u256): u256 { fresh() }
 ```
 
-This is the canonical way to axiomatize external/stubbed dependencies. Specs in the target file then reference the real callees naturally and the prover substitutes the spec summaries. See `references/spec-patterns.md` §4.10 for the full pattern.
+This is the canonical way to axiomatize external/stubbed dependencies — see `references/spec-patterns.md` §4.10. **Every axiom is trusted, not proved** — record each one for the report's "Trusted axioms" disclosure (Phase 5, L6).
 
-**Cross-module fallback.** If the colocated spec causes a compile error, offer to create a sidecar `<pkg>_specs/` package and emit the spec there with `target = pkg::mod::fn`. **AskUserQuestion before creating files outside the user's package directory.**
+**Inline fallback (`--inline` only).** When the user chose the inline layout at Phase 3.5, write the spec at the bottom of the production `.move` between markers, named `<fn>_spec` with no `target =`:
+
+```move
+// === sui-pilot specify: generated specs (do not edit between markers) ===
+#[spec_only]
+use prover::prover::{requires, ensures, asserts, clone};
+
+#[spec(prove)]
+fun <name>_spec(...) { ... }
+// === end sui-pilot specify ===
+```
+
+Idempotency: if the marker block exists, splice into it; never duplicate a `#[spec(...)]` for the same function.
 
 ### 4.6 Verify (MCP)
 
-`mcp__sui-prover__prove_package` with `target_function: "<pkg>::<mod>::<name>_spec"` and `timeout_seconds: 60` (configurable).
+`mcp__sui-prover__prove_package` with `move_toml_path` pointed at the **spec package** (`<pkg>_specs/Move.toml`), `target_function: "<pkg>_specs::<mod>_specs::<fn>_spec"`, and `timeout_seconds: 60` (configurable). In the `--inline` fallback the target is `<pkg>::<mod>::<fn>_spec` against the production `Move.toml`.
+
+**Custom prover config → second spec package (L5).** Some functions can only be proved under a non-default prover invocation — most commonly bit-exact bitwise/shift/wrapping semantics that need `--no-bv-int-encoding` (the integer encoding can't model them). When a spec fails or times out and the diagnosis (Phase 4.7) points at bit-level reasoning:
+
+1. Create `<pkg>_specs_bv/` on demand (same scaffold as Phase 3.5, distinct name `<Pkg>SpecsBV`, address `<pkg>_specs_bv`).
+2. Move that one spec there and re-verify with the flag set, e.g. `extra_args: ["--no-bv-int-encoding"]`.
+3. Record the function's package + flag set in `.specify-progress.json` under `prover_flags` so Phase 5's manifest and report can show *which encoding each spec needed and why* (itself an audit-relevant fact — it signals the property is bit-level).
+
+Most packages never need a `_bv` package; create it only when a spec actually demands it.
 
 ### 4.7 Diagnose failures
 
@@ -248,21 +327,87 @@ Default `attempts ≤ 3` per function. Configurable via Phase 3 batch.
 Update `.specify-progress.json` after each iteration. Schema:
 ```json
 {
-  "function_id": {
-    "status": "pending" | "drafted" | "verified" | "skipped" | "needs_human" | "failed",
-    "attempts": N,
-    "last_error": "..."
+  "layout": "package" | "inline",
+  "spec_packages": ["<pkg>_specs", "<pkg>_specs_bv"],
+  "trusted_axioms": [
+    { "target": "fixed::mul_down", "file": "<pkg>_specs/sources/specify_axioms.move", "assumption": "unconstrained — no postcondition" }
+  ],
+  "functions": {
+    "function_id": {
+      "status": "pending" | "drafted" | "verified" | "skipped" | "needs_human" | "failed",
+      "attempts": N,
+      "last_error": "...",
+      "spec_package": "<pkg>_specs",
+      "prover_flags": ["--no-bv-int-encoding"],
+      "abort_conditions": "aborts unless shift < 128",
+      "invariant": "INV-supply-conservation"
+    }
   }
 }
 ```
+`layout`, `spec_packages`, and per-function `prover_flags` / `spec_package` make resume deterministic and feed Phase 5's manifest. `trusted_axioms` accumulates every `#[spec(skip, target = …)]` for the report's disclosure section.
 
-## Phase 5 — Hand off
+## Phase 5 — Hand off (deliverable)
 
-When the user pauses, or when all pending functions are processed:
+When the user pauses, or when all pending functions are processed, emit the full deliverable. Per "Deliverable shape" this is the manifest + the report; the spec packages already exist on disk from Phase 4.
 
-1. Write `.specify-report.html` at the package root — self-contained, semantic HTML5, inline CSS. Sections: package summary, per-function status, generated specs (with syntax-highlighted code blocks), open issues, next steps.
-2. Print a one-screen summary to the chat: "X verified, Y drafted-but-failing, Z needs-human, K skipped. Report at `<path>`."
-3. Offer to `git diff` the new spec blocks so the user can review the changes.
+### 5.1 Verification-context manifest (Q4 / L5)
+
+Write `spec-context.json` next to the report. It binds the proof to the state it was proved against, so a reviewer can reproduce it:
+
+```json
+{
+  "generated_at": "<ISO8601>",
+  "hash_method": "bytecode" | "normalized_source",
+  "production_package": { "name": "<pkg>", "source_hashes": { "<mod>::<fn>": "<8-char>" } },
+  "spec_packages": [
+    { "package": "<pkg>_specs",    "flags": [] },
+    { "package": "<pkg>_specs_bv", "flags": ["--no-bv-int-encoding"] }
+  ],
+  "deps": [ { "name": "...", "rev": "...", "pinned_to_branch": false } ],
+  "toolchain": { "sui_prover": "...", "sui_cli": "...", "boogie": "...", "z3": "..." }
+}
+```
+
+Source hashes are **per-function** (minimize false-positive staleness) over compiled bytecode where available, else normalized source. Reuse `dep-pins-capture` logic for the `deps` block rather than duplicating it. Toolchain versions come from the Phase 0 `prover_capabilities` probe. **v1 is manifest-only** — capture, no preflight clone, no drift enforcement (those are roadmap v2/v3; design doc Q4).
+
+### 5.2 The report — invariant-driven, hybrid granularity (Q5 / Q1)
+
+Write per-module `<mod>.spec.html` next to each spec module, plus a package-level `index.html`. `--single-file` collapses to one file for tiny packages. Each file is self-contained semantic HTML5 with inline CSS (match the house style in `docs/*.html`).
+
+**Structured sections via markers (Q2).** Machine-derived zones regenerate every run; human-authored prose is preserved. Wrap each:
+
+```html
+<!-- specify:auto:begin coverage-matrix -->  ... regenerated ...  <!-- specify:auto:end -->
+<!-- specify:human:begin intent-INV-supply-conservation -->  ... preserved ...  <!-- specify:human:end -->
+```
+
+On regen, replace only content between `auto:` markers; never touch `human:` zones.
+
+**Module report structure (invariant-driven):**
+1. Module overview (`specify:human`).
+2. **Invariants** — one entry per property the module guarantees. Each carries: statement (formal + prose), functions involved, and the required sections: **Abort conditions** (L2 — the exact abort set per function, or "does not abort"), **Threat model**, **Proof obligations** (the defining-property `ensures` from Phase 4.2 *are* the obligations), plus the Q2 template (Intent / Alternatives / Limitations / Open questions). Counterexamples appear here under `--audit` only.
+3. **Function-local guarantees** — bucket for specs with no cross-cutting invariant.
+4. **Function index (appendix, auto)** — every spec'd fn: signature, the two source hashes (production fn + spec), prover-flag set if non-default, → links to the invariant(s) it serves.
+
+Invariants are named human-readable + stable slug (`INV-supply-conservation`); the source→invariant link is an explicit `// invariant: supply-conservation` marker above the `#[spec(prove)]` in the spec module (survives report regen).
+
+**Limitations section must enumerate trusted axioms (L6).** Under a "Trusted axioms — not proved" heading, list every `#[spec(skip, target = …)]` from `.specify-progress.json` `trusted_axioms[]` (target + file + the assumption in prose) **and** every hand-written `prelude_extra.bpl` axiom if one was used. These are holes in the verification — a wrong axiom makes the proof vacuous, so they're the auditor's first read.
+
+**Package `index.html`:** package overview + top-level claim; cross-module invariants with proof-obligation mapping (which spec in which module discharges which obligation); coverage matrix (module × invariant, every externally-reachable fn marked specified / deliberately-skipped / known-gap *with a reason* — negative space is first-class, L9); per-module summaries with links; the manifest's toolchain + dep pins.
+
+### 5.3 `--audit` extras (opt-in)
+
+Only when the user passed `--audit`:
+
+- **Counterexample regressions (L7).** When a spec produced a counterexample during Phase 4, persist the failing input + the offending production snippet as a named regression beside the spec (the integer-library pattern: keep the buggy fn so the spec demonstrably fails on it). Leaner than a freeform journal and doubles as a vacuity check.
+- **CI stub (L8).** Emit a `.github/workflows/prover.yml` stub that brew-installs sui-prover and runs it once per spec package with that package's flag set (from the manifest). This *is* drift enforcement — frame `/verify --strict` as "the thing CI runs."
+
+### 5.4 Summary
+
+1. Print a one-screen chat summary: "X verified, Y drafted-but-failing, Z needs-human, K skipped. Spec package(s): `<pkg>_specs[, <pkg>_specs_bv]`. Report at `<path>`."
+2. Offer to `git diff` the spec package(s) so the user can review (production source is unchanged — call that out explicitly).
+3. Point the user at the consumer: once specs are in place, **`/verify`** re-proves them against current code and flags drift using the `spec-context.json` this phase emitted (`/verify --strict` is the CI posture). `/specify` authors; `/verify` checks.
 
 ## Resumability
 
@@ -270,7 +415,9 @@ Any run starts at Phase 0 → Phase 1, then loads `.specify-progress.json` and s
 
 ## Operating rules
 
-- **Never auto-edit the user's `Move.toml`.** Surface setup issues; let the user fix them.
+- **Never modify the production package in the default flow.** No `#[spec_only]`, no prover dependency, no marker blocks in the production source; no edits to the production `Move.toml`. Specs go in the sibling `<pkg>_specs/` package, which the skill owns and may create/edit freely. The only exception is the explicit `--inline` opt-out, which writes marker blocks into the production source.
+- **Never auto-edit the user's production `Move.toml`.** Surface setup issues (explicit `Sui`/`MoveStdlib` deps, edition) and let the user fix them. The skill *does* author the spec package's own `Move.toml` (Phase 3.5) — that file is a generated deliverable, not the user's.
+- **Trusted axioms are disclosed, never hidden.** Every `#[spec(skip, target = …)]` and every `prelude_extra.bpl` axiom must land in the report's "Trusted axioms — not proved" section. An undisclosed axiom is a silent hole in the verification.
 - **Never spec a `public(package)` function.** The user's intent (per the plan) is external-API specs only.
 - **Never emit legacy MSL syntax.** No `aborts_if`, no `pragma`, no free `axiom`. See `references/spec-patterns.md` for the modern equivalents.
 - **Never duplicate a `#[spec(...)]` for the same function.** Idempotency via the marker block.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -229,7 +229,7 @@ public fun <fn>_spec(<params>): <return_type> {
 }
 ```
 
-The `target = <fn>` attribute binds the spec to the imported production function; the spec body **must call** the target (see failure-taxonomy `spec_target_body_no_call`). Imports of the production functions/types go in a plain `use <pkg>::<mod>::{...}` block; only the `prover::*` imports get `#[spec_only]`.
+The `target = <fn>` attribute binds the spec to the imported production function; the spec body **must call** the target (see failure-taxonomy `spec_target_body_no_call`). The templates use the **bare** `target = <fn>` because the function is in scope via the `use <pkg>::<mod>::{<fn>}` import (the proven integer-library idiom); if it isn't imported, use the qualified `target = <pkg>::<mod>::<fn>` — see `references/spec-patterns.md` §3. Imports of the production functions/types go in a plain `use <pkg>::<mod>::{...}` block; only the `prover::*` imports get `#[spec_only]`.
 
 **Inline shape (`--inline` opt-out only).** When the user chose the inline layout, render the legacy in-source twin (no `target =`, spec named `<fn>_spec`, written between markers in the production `.move`) per `references/spec-patterns.md` §2. Never use the inline shape in the default flow.
 

--- a/skills/specify/references/failure-taxonomy.md
+++ b/skills/specify/references/failure-taxonomy.md
@@ -88,7 +88,7 @@ Findings always carry `raw_stdout` / `raw_stderr` as the escape hatch — if a k
 **Remediation.** In escalation order:
 
 1. **Increase `timeout_seconds`** — start at 60s, try 120s, then 300s.
-2. **Add `--split-paths=N`** via `extra_args` (start at 4, try 8). The workshop example uses `--split-paths=4`.
+2. **Add `--split-paths=N`** via `extra_args` (start at 4, try 8). The workshop example uses `--split-paths=4`. Always use the `=`-joined form (one array element); `extra_args` splits each token on `=`, so a space-separated `"--split-paths", "4"` would drop the value (`prove.ts`).
 3. **Per-spec `boogie_opt` tuning.** See §4.9 of spec-patterns. Start with `vcsMaxKeepGoingSplits:2`. Keep tokens verbatim across retries.
 4. **Narrow the spec.** If three escalations don't help, the spec might be asking the prover to discharge too much in one go. Split into multiple smaller specs (e.g. one for the abort path, one for the functional postcondition).
 5. **Bit-level semantics → second spec package.** If the timeout is on bitwise/shift/wrapping reasoning (the integer encoding can't model it efficiently), move that one spec to a `<pkg>_specs_bv/` package proved with `extra_args: ["--no-bv-int-encoding"]`. See spec-patterns §8; record the flag in `.specify-progress.json` `prover_flags` for the manifest.

--- a/skills/specify/references/failure-taxonomy.md
+++ b/skills/specify/references/failure-taxonomy.md
@@ -37,11 +37,11 @@ Findings always carry `raw_stdout` / `raw_stderr` as the escape hatch — if a k
 **Remediation.**
 
 1. `mcp__move-lsp__move_diagnostics` on the affected file to confirm where the compiler complains.
-2. If the diagnostic points at the spec block we just wrote:
-   - Re-read `references/spec-patterns.md` §1 for the import shape.
-   - Check that every `prover::...` function used in the spec is imported.
-   - Check that the function name in the spec matches an actual function in the module.
-3. If the diagnostic points at the colocated-spec compile bug, switch to the sidecar package pattern (§3 of spec-patterns).
+2. If the diagnostic points at the spec we just wrote:
+   - Re-read `references/spec-patterns.md` §3 for the separate-package shape (the default) and §1 for the import shape.
+   - Check that every `prover::...` function used in the spec is imported under `#[spec_only]`, and every production function/type under a plain `use <pkg>::<mod>::{...}`.
+   - Check that the `target = <fn>` attribute names a real function in the production module, and that the spec body actually calls it (else `spec_target_body_no_call`).
+3. If the failure only happens in the `--inline` layout (the colocated-spec compile bug), switch to the **default separate-package layout** (§3 of spec-patterns) — this is exactly the failure mode the default avoids.
 4. If the diagnostic points at a pre-existing issue, surface it and ask the user — don't try to fix unrelated bugs from inside `specify`.
 
 ## kind: `asserts_failed`
@@ -91,6 +91,7 @@ Findings always carry `raw_stdout` / `raw_stderr` as the escape hatch — if a k
 2. **Add `--split-paths=N`** via `extra_args` (start at 4, try 8). The workshop example uses `--split-paths=4`.
 3. **Per-spec `boogie_opt` tuning.** See §4.9 of spec-patterns. Start with `vcsMaxKeepGoingSplits:2`. Keep tokens verbatim across retries.
 4. **Narrow the spec.** If three escalations don't help, the spec might be asking the prover to discharge too much in one go. Split into multiple smaller specs (e.g. one for the abort path, one for the functional postcondition).
+5. **Bit-level semantics → second spec package.** If the timeout is on bitwise/shift/wrapping reasoning (the integer encoding can't model it efficiently), move that one spec to a `<pkg>_specs_bv/` package proved with `extra_args: ["--no-bv-int-encoding"]`. See spec-patterns §8; record the flag in `.specify-progress.json` `prover_flags` for the manifest.
 
 ## kind: `dep_address_conflict`
 
@@ -128,9 +129,9 @@ Caused by:
 
 **Remediation.**
 
-1. Confirm the source file actually contains a `#[spec(prove)] fun <name>_spec(...)` block — sui-prover targets the spec function, not the function under test. The naming convention is `<fn>_spec`; for `target_function: "pkg::mod::foo"`, the spec must be named `pkg::mod::foo_spec`.
+1. sui-prover targets the **spec** function, not the function under test. In the default separate-package layout the spec lives in `<pkg>_specs::<mod>_specs` as `<fn>_spec` with `#[spec(prove, target = <fn>)]`, so the target is `<pkg>_specs::<mod>_specs::<fn>_spec` — and `prove_package` must point `move_toml_path` at the spec package, not the production package. In the `--inline` layout it's `<pkg>::<mod>::<fn>_spec`.
 2. Confirm the package built successfully on the previous run (a stale build cache can leave the prover targeting an older symbol table).
-3. If the spec lives in a sidecar axiom file with `#[spec(target = pkg::mod::foo)]`, target the spec function's name (`<sidecar>::foo_spec`), not the original function.
+3. If the spec lives in the axiom file (`<pkg>_specs/sources/specify_axioms.move`) with `#[spec(skip, target = pkg::mod::foo)]`, target the spec function's name (`<pkg>_specs::specify_axioms::foo_spec`), not the original function.
 
 ## kind: `spec_target_body_no_call`
 

--- a/skills/specify/references/spec-patterns.md
+++ b/skills/specify/references/spec-patterns.md
@@ -30,6 +30,8 @@ Attribute exclusion for `#[test_only]` / `#[test]`:
 
 ## 2. Canonical spec body shape
 
+> The body shape below is the same whether the spec is inline or in a separate package. The **default layout wraps it in a separate spec package with `#[spec(prove, target = <fn>)]`** — see §3. The bare `#[spec(prove)]` form shown here is the `--inline` opt-out.
+
 The minimal twin function pattern (from `.sui-prover-docs/guide/SKILL.md`):
 
 ```move
@@ -53,28 +55,44 @@ use prover::prover::{requires, ensures, asserts, clone};
 use prover::ghost::{declare_global, global};   // only when using ghost state
 ```
 
-## 3. The colocation-vs-sidecar choice
+## 3. Spec layout — separate package is the default
 
-The Asymptotic SKILL.md warns:
+**The default layout is a separate sibling spec package** — not inline specs in the production source. This matches how real audit-grade engagements ship (`~/workspace/integer-library`: `specs/` package depending on the production package; design doc L1) and it keeps the deployed package pristine — no `#[spec_only]`, no prover dependency, no marker blocks.
+
+The Asymptotic SKILL.md also warns colocation is fragile:
 
 > Specs may cause compile errors when placed alongside regular Move code due to prover-specific changes in the compilation pipeline. If this happens, create a separate package for specs and use the `target` attribute.
 
-Workflow:
+So separate-package is both the cleaner deliverable *and* the more robust one. Layout:
 
-1. Try colocation first (it's what every example in `.sui-prover-docs/examples/` does).
-2. If the compile fails *only* after the spec block is written, fall back to a sidecar package `<pkg>_specs/`:
+```
+<pkg>_specs/
+  Move.toml          # name = "<Pkg>Specs", edition = "2024.beta", dep <Pkg> = { local = "../<pkg>" }
+  sources/
+    <mod>_specs.move # one per production module
+```
 
-   ```move
-   module <pkg>_specs::<mod>;
+```move
+module <pkg>_specs::<mod>_specs;
 
-   #[spec(prove, target = <pkg>::<mod>::<fn>)]
-   public fun <fn>_spec(<params>): <return_type> {
-       <pkg>::<mod>::<fn>(<args>)
-       // requires / ensures / asserts as usual
-   }
-   ```
+use <pkg>::<mod>::{<fn>, /* types in the signature */};
 
-3. The skill must ask the user (`AskUserQuestion`) before creating files outside the user's package directory.
+#[spec_only]
+use prover::prover::{ensures, asserts, requires, clone};
+
+#[spec(prove, target = <fn>)]
+public fun <fn>_spec(<params>): <return_type> {
+    // requires / asserts / ensures as usual
+    let r = <fn>(<args>);   // MUST call the target (failure-taxonomy: spec_target_body_no_call)
+    r
+}
+```
+
+- `target = <fn>` binds the spec to the imported production function; the body must call it.
+- Production functions/types use a plain `use <pkg>::<mod>::{...}`; only `prover::*` imports get `#[spec_only]`.
+- A function needing a non-default prover invocation goes in a *second* package — see §8.
+
+**`--inline` opt-out.** Only for single trivial modules where a sibling package is overkill. Writes the legacy in-source marker-block twin (§2, no `target =`). Never the default.
 
 ## 4. Common patterns
 
@@ -220,10 +238,10 @@ fun withdraw_spec<A, B>(pool: &mut Pool<A, B>, lp_in: Balance<LP<A, B>>): (Balan
 
 Real-world Move packages often depend on libraries whose **source isn't shipped** — the dep's public-bytecode interface is exported but every function body is `abort 0` (the canonical stub shape used when a vendor publishes the ABI but keeps the implementation closed). A prover invoked on such a package concludes every caller path aborts (because every callee aborts), so any spec verifies *vacuously*: the `_Check` and `_Assume` subchecks pass but say nothing about the real math.
 
-The fix is **axiomatic modeling** of the stub callees via a dedicated sidecar file `sources/specify_axioms.move`:
+The fix is **axiomatic modeling** of the stub callees via a dedicated file in the **spec package** (the default layout, §3) — `<pkg>_specs/sources/specify_axioms.move`. The axioms target the stubbed callees of the production package's deps; keeping them in the spec package means the production source stays untouched:
 
 ```move
-module <pkg>::specify_axioms;
+module <pkg>_specs::specify_axioms;
 
 #[spec_only]
 use prover::prover::{fresh};
@@ -290,3 +308,126 @@ The Sui Prover does **not** use the legacy Move Prover MSL keywords. Common drif
 | `invariant <expr>` block | `invariant!` macro (loops) or `<Type>_inv` naming + `#[spec_only(inv_target = T)]` (data invariants) |
 
 If a user pastes legacy MSL into a spec the skill is reviewing, surface this table and ask whether to translate or abort.
+
+## 6. Modeling a custom numeric type (the `Integer` math-domain idiom)
+
+For any package with a custom numeric type — a `struct` wrapping an integer field (signed ints, fixed-point, Q64.64, etc.) — specs must reason in the **unbounded mathematical domain** `std::integer::Integer`, not in machine bits. Lift each value with `.to_int()`, do the math in `Integer`, compare. The prover then never wrestles with two's-complement bit-fiddling, which is otherwise intractable. (Pattern distilled from `~/workspace/integer-library`'s verified `i128_specs.move`, L3.)
+
+**Model the type once, at the top of the spec module, then reuse via `use fun`:**
+
+```move
+module integer_library_specs::i128_specs;
+
+use integer_library::i128::I128;       // + the functions being spec'd
+
+#[spec_only] use std::integer::Integer;
+#[spec_only] use prover::prover::{ensures, asserts};
+
+const MIN_AS_U128: u128 = 0x80000000000000000000000000000000;
+const MAX_AS_U128: u128 = 0x7fffffffffffffffffffffffffffffff;
+
+// 1. Reinterpret the raw bits as a signed mathematical integer (two's complement).
+#[spec_only]
+fun to_signed_int(x: u128): Integer {
+    if (x <= MAX_AS_U128) { x.to_int() }
+    else { x.to_int().sub(0x100000000000000000000000000000000u256.to_int()) }
+}
+
+// 2. Lift the wrapper type into the math domain.
+#[spec_only]
+fun to_int(v: I128): Integer { v.as_u128().to_signed_int() }
+
+// 3. Range predicate — "does this math value fit the type?" (drives abort specs).
+#[spec_only]
+fun is_i128(v: Integer): bool {
+    v.gte(MIN_AS_U128.to_signed_int()) && v.lte(MAX_AS_U128.to_signed_int())
+}
+
+// 4. Domain-specific helper ops, also in Integer space.
+#[spec_only]
+public fun int_div_trunc(x: Integer, y: Integer): Integer {
+    let q = x.abs().div(y.abs());
+    if (x.is_pos() && y.is_pos() || x.is_neg() && y.is_neg()) { q } else { q.neg() }
+}
+
+// 5. `use fun` aliases so specs read like the math.
+use fun to_int as I128.to_int;
+use fun to_signed_int as u128.to_signed_int;
+use fun int_div_trunc as Integer.div_trunc;
+```
+
+With the model in place, specs are short and legible — the abort contract uses the range predicate, the postcondition states the math:
+
+```move
+#[spec(prove, target = add)]
+public fun add_spec(num1: I128, num2: I128): I128 {
+    let sum = num1.to_int().add(num2.to_int());
+    asserts(is_i128(sum));                 // aborts iff the true sum doesn't fit
+    let result = add(num1, num2);
+    ensures(result.to_int() == sum);        // exact, in Integer space
+    result
+}
+```
+
+**Phase 4.3 should emit this model block first** when it detects a wrapper struct over an integer field, before any per-function spec. Put it once per spec module (or a shared spec module imported by the others).
+
+## 7. Defining-property postconditions (prefer over recomputation)
+
+The weakest useful `ensures` is `result == <recompute the formula>`: it re-derives the implementation in spec language, so a wrong mental model passes against a wrong implementation. Prefer the **defining property** — the algebraic relation that characterizes the result regardless of how it's computed. (From integer-library's `full_math` / `math_u256` specs, L4.)
+
+| Function | Recomputation (weak) | Defining property (strong) |
+|---|---|---|
+| floor div `mul_div_floor` | `result == p / d` | `result*d <= p  &&  p < (result+1)*d` |
+| `div_mod` | `(p, r) == (num/d, num%d)` | `p*d + r == num  &&  r < d` |
+| ceil div | `result == (p + d-1)/d` | `(result-1)*d < p  &&  p <= result*d` |
+| `add_check` (overflow test) | mirror the impl's branch | `result == (a+b <= MAX)` in Integer space |
+
+Real example — note the functional `ensures` *and* the bounding inequalities together:
+
+```move
+#[spec(prove, target = mul_div_floor)]
+public fun mul_div_floor_spec(num1: u64, num2: u64, denom: u64): u64 {
+    asserts(denom > 0);
+    let product = num1.to_int().mul(num2.to_int());
+    let expected = product.div(denom.to_int());
+    asserts(expected.lte(std::u64::max_value!().to_int()));
+    let result = mul_div_floor(num1, num2, denom);
+    ensures(result.to_int() == expected);                                   // functional
+    ensures(result.to_int().mul(denom.to_int()).lte(product));              // result*d <= p
+    ensures(product.lt(result.to_int().add(1u64.to_int()).mul(denom.to_int()))); // p < (result+1)*d
+    result
+}
+```
+
+Offer defining-property as the recommended postcondition tier in Phase 4.2 for division, rounding, sqrt, and any inverse-relation function. These inequalities *are* the report's "Proof obligations" (Phase 5).
+
+## 8. Multiple spec packages & custom prover configs
+
+A single production package can need **more than one spec package**, each proved with a different prover invocation. The canonical case (integer-library, L5): bit-exact bitwise/shift/wrapping semantics can't be modeled in the default integer encoding and must be proved with `--no-bv-int-encoding` (bitvector encoding). Those specs live in a second package:
+
+```
+<pkg>_specs/      → sui-prover                       # default integer encoding
+<pkg>_specs_bv/   → sui-prover --no-bv-int-encoding  # bit-exact semantics
+```
+
+- Create `<pkg>_specs_bv/` **lazily** — only when a spec fails/times out and the diagnosis points at bit-level reasoning (Phase 4.6).
+- Record each function's package + flag set in `.specify-progress.json` `prover_flags` and surface it in the report — *which encoding a function needed is itself audit signal* (it tells you the property is bit-level).
+- In the bv package the proof sometimes needs a `native fun` bound to a Boogie procedure (e.g. `ashr`) plus a custom prelude — see below.
+
+### 8.1 `prelude_extra.bpl` — hand-written axioms (TRUSTED, NOT PROVED)
+
+When Boogie can't derive a fact, the engagement adds it as an axiom in a `prelude_extra.bpl` shipped beside the spec package's `Move.toml`. integer-library's prelude teaches Boogie things like:
+
+```
+axiom (forall x: int :: {$xorInt'u128'(x, $MAX_U128)} $xorInt'u128'(x, $MAX_U128) == $MAX_U128 - x);
+axiom (forall x: int :: {$andInt'u128'(x, $LO_64_MASK)} $andInt'u128'(x, $LO_64_MASK) == x mod $TWO_POW_64);
+axiom (forall x: int :: {$shr(x, 127)} $shr(x, 127) == x div $TWO_POW_127);
+```
+
+…and the bv prelude binds a native `ashr` to `$AShr'BvN'`.
+
+**Every line in `prelude_extra.bpl` is a hole in the verification.** An axiom is assumed true, never checked — if it's wrong, every proof that relies on it is vacuous. Therefore:
+
+- Treat the prelude as an **escape hatch of last resort**, after `requires`-strengthening, `no_opaque`, `--split-paths`, and `boogie_opt` (failure-taxonomy `timeout` / `ensures_failed`) have failed.
+- **Every axiom must be disclosed** in the report's "Trusted axioms — not proved" section (Phase 5, L6): the axiom, the file+line, and a prose justification of why it's sound. This is the single most audit-critical content in the deliverable.
+- Prefer the narrowest axiom that unblocks the proof (a single masking identity), never a broad one.

--- a/skills/specify/references/spec-patterns.md
+++ b/skills/specify/references/spec-patterns.md
@@ -88,7 +88,7 @@ public fun <fn>_spec(<params>): <return_type> {
 }
 ```
 
-- `target = <fn>` binds the spec to the imported production function; the body must call it.
+- `target = <fn>` binds the spec to the production function brought into scope by the `use <pkg>::<mod>::{<fn>}` import; the body must call it. The bare (unqualified) `target = <fn>` is the proven idiom in the `integer-library` reference (e.g. `#[spec(prove, target = add)]` with `use integer_library::i128::{add}`) — it resolves *because* the function is imported. If the target isn't imported, qualify it: `target = <pkg>::<mod>::<fn>` (the form the bundled prover docs show). Either resolves; bare depends on the `use`.
 - Production functions/types use a plain `use <pkg>::<mod>::{...}`; only `prover::*` imports get `#[spec_only]`.
 - A function needing a non-default prover invocation goes in a *second* package — see §8.
 
@@ -412,11 +412,18 @@ A single production package can need **more than one spec package**, each proved
 
 - Create `<pkg>_specs_bv/` **lazily** — only when a spec fails/times out and the diagnosis points at bit-level reasoning (Phase 4.6).
 - Record each function's package + flag set in `.specify-progress.json` `prover_flags` and surface it in the report — *which encoding a function needed is itself audit signal* (it tells you the property is bit-level).
-- In the bv package the proof sometimes needs a `native fun` bound to a Boogie procedure (e.g. `ashr`) plus a custom prelude — see below.
+- In the bv package the proof sometimes needs a `native fun` bound to a Boogie procedure (e.g. `ashr`) plus a custom `extra_bpl` file — see below.
 
-### 8.1 `prelude_extra.bpl` — hand-written axioms (TRUSTED, NOT PROVED)
+### 8.1 Extra-Boogie axioms via `extra_bpl` (TRUSTED, NOT PROVED)
 
-When Boogie can't derive a fact, the engagement adds it as an axiom in a `prelude_extra.bpl` shipped beside the spec package's `Move.toml`. integer-library's prelude teaches Boogie things like:
+When Boogie can't derive a fact, you add it as an axiom in a hand-written `.bpl` file. **The prover does not auto-load any file by name** — you wire the file in explicitly with the `extra_bpl` attribute, placing the `.bpl` in the **same directory as the spec module** (per `.sui-prover-docs/guide/SKILL.md` §"extra_bpl" and `spec-reference.md`):
+
+```move
+#[spec_only(extra_bpl = b"mymodule_prelude.bpl")]
+module <pkg>_specs::<mod>_specs;
+```
+
+(integer-library ships such files; in its build they happen to be named `prelude_extra.bpl`, but the load is driven by the attribute, not the filename.) The `.bpl` teaches Boogie facts like:
 
 ```
 axiom (forall x: int :: {$xorInt'u128'(x, $MAX_U128)} $xorInt'u128'(x, $MAX_U128) == $MAX_U128 - x);
@@ -426,8 +433,9 @@ axiom (forall x: int :: {$shr(x, 127)} $shr(x, 127) == x div $TWO_POW_127);
 
 …and the bv prelude binds a native `ashr` to `$AShr'BvN'`.
 
-**Every line in `prelude_extra.bpl` is a hole in the verification.** An axiom is assumed true, never checked — if it's wrong, every proof that relies on it is vacuous. Therefore:
+**Every line in an `extra_bpl` axiom file is a hole in the verification.** An axiom is assumed true, never checked — if it's wrong, every proof that relies on it is vacuous. Therefore:
 
-- Treat the prelude as an **escape hatch of last resort**, after `requires`-strengthening, `no_opaque`, `--split-paths`, and `boogie_opt` (failure-taxonomy `timeout` / `ensures_failed`) have failed.
+- Treat extra-Boogie axioms as an **escape hatch of last resort**, after `requires`-strengthening, `no_opaque`, `--split-paths`, and `boogie_opt` (failure-taxonomy `timeout` / `ensures_failed`) have failed.
+- **`/specify` does not auto-author these.** Writing trusted axioms is a human judgment call (each one weakens the proof). When a spec genuinely needs one, `/specify` creates the `.bpl` in the spec module's directory, wires it via the `extra_bpl` attribute, and **surfaces it to the user for confirmation** rather than inventing axioms silently. Phase 4.6 escalation routes here only as the final step.
 - **Every axiom must be disclosed** in the report's "Trusted axioms — not proved" section (Phase 5, L6): the axiom, the file+line, and a prose justification of why it's sound. This is the single most audit-critical content in the deliverable.
 - Prefer the narrowest axiom that unblocks the proof (a single masking identity), never a broad one.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: verify
+description: "Re-verifies the formal specifications that `/specify` authored — the consumer half of the FV split. Reads the `spec-context.json` manifest, detects drift (source changed under a bound spec, deps/toolchain moved, new externally-reachable functions left uncovered), re-runs sui-prover on every spec package with its recorded flags, and reports which guarantees still hold, which were violated, and which went stale. Use this skill when the user invokes `/verify`, asks to 're-verify', 'check the specs still hold', 'is this proof still valid', 'run the prover against current code', or wires FV into CI. `/verify --strict` is the thing CI runs (refuse-on-drift, non-zero exit on any failure or staleness). Does NOT author or edit specs — that is `/specify`'s job; when `/verify` finds uncovered functions it points the user at `/specify`, never writes the spec itself. Skip when sui-prover isn't installed or the package has no specs at all."
+---
+
+# Verify — re-check Sui Move formal specifications against current code
+
+> **Doc-First Requirement.** The spec language is the Sui Prover's, not legacy MSL. When interpreting `prove_package` findings, use the shared `../specify/references/failure-taxonomy.md` and `.sui-prover-docs/guide/spec-reference.md`. `/verify` reads and re-proves specs — it never emits new spec syntax.
+
+## What `/verify` is (and is not)
+
+`/specify` and `/verify` are the two halves of the FV workflow (design doc `docs/specify-deliverable-design.html`, Q4):
+
+- **`/specify` authors.** It writes `#[spec(prove, target = …)]` twins into a sibling `<pkg>_specs/` package and emits a `spec-context.json` manifest binding each spec to the exact state it was proved against.
+- **`/verify` checks.** It is **read-mostly** — it re-proves the existing specs against *current* source/deps/toolchain and reports drift. It writes only a report (and optionally refreshes drift badges in `/specify`'s report). It never authors, edits, or deletes a spec.
+
+A spec is a claim of the form *"this code, at this state, against these deps, satisfies this property."* `/verify`'s job is to answer **"is that claim still true, and is it still about the current code?"** Those are two different questions — a spec can still *pass* yet no longer *describe* the code (source drifted), and a spec can *fail* on unchanged code (a real regression). `/verify` distinguishes them (Phase 4).
+
+## Inputs and modes
+
+- **Manifest-driven (full).** When `spec-context.json` exists (a package `/specify` produced), `/verify` does drift-aware verification: per-function source-hash comparison, dep/toolchain reproducibility checks, coverage drift, then re-prove.
+- **Degraded (no manifest).** When there is no `spec-context.json` (hand-written specs, e.g. `~/workspace/integer-library`, or specs predating the manifest), `/verify` still works: it discovers the spec package(s), re-proves them, and reports verdicts — but **announces that drift detection is unavailable** (no bound state to compare against) and suggests running `/specify` once to mint a manifest.
+
+## Flags
+
+- `--strict` — **refuse-on-drift, CI posture.** Any staleness, context drift, coverage gap, or spec failure makes `/verify` exit non-zero. This is exactly what the `prover.yml` stub `/specify --audit` emits runs. Default (no flag) is **warn-and-run**: report everything, exit zero unless a spec hard-fails.
+- `--report <path>` — where to write the HTML report (default `.verify-report.html` at the package root).
+- `--package <name>` — verify only one spec package (e.g. `<pkg>_specs_bv`); default verifies all packages in the manifest.
+
+## Phase 0 — Validate (single shot)
+
+Same hard gate as `/specify` Phase 0 — do not duplicate the logic, follow it:
+
+1. **Binary probe.** `mcp__sui-prover__prover_capabilities` with `move_toml_path` at the package root. Capture `binary.found`, `binary.version`, `binary.sui_prover_flags`, `setup_warnings`, `git_dependencies`, and the toolchain versions (needed for Phase 2c).
+2. **Binary missing.** If `binary.found === false`: in `--strict` exit non-zero with a clear "prover unavailable" verdict; interactive, ask the user to `brew install asymptotic-code/sui-prover/sui-prover`. `/verify` cannot run degraded without the binary (unlike `/specify`'s discovery-only mode — there is nothing to discover here).
+3. **Compile-health + private-dep gates.** Identical to `/specify` Phase 0 steps 2–3. A package that won't resolve its deps can't be re-proved; surface the blocker and exit (non-zero in `--strict`).
+
+## Phase 1 — Load verification context
+
+1. Find `spec-context.json` at the package root. If absent → **degraded mode** (announce it; skip Phase 2a/2c hash+context comparison, keep 2b coverage and Phase 3 re-prove).
+2. Parse the manifest: `production_package.source_hashes` (per `<mod>::<fn>`), `hash_method`, `spec_packages[]` (name + `flags`), `deps[]` (name + rev + `pinned_to_branch`), `toolchain`.
+3. Resolve each spec package directory on disk. If a manifest-listed spec package is missing, that is itself drift — record it and (in `--strict`) fail.
+4. `mcp__sui-prover__list_specs` on each spec package → the live set of `#[spec(...)]` twins and their `target =` mappings. Cross-check against the manifest's specified set (feeds Phase 2b).
+
+## Phase 2 — Detect drift
+
+Three independent drift axes. Collect all; don't short-circuit.
+
+### 2a — Source drift (per-function hash)
+
+For each `<mod>::<fn>` with a bound hash in the manifest:
+
+1. Recompute the current hash **using the manifest's `hash_method`** (bytecode hash if it says `bytecode`, else normalized-source hash — strip comments/whitespace over the function span). Mirroring the method is essential; a different method produces false drift.
+2. Compare to the bound hash. Equal → **fresh**. Different → **stale** (the production function changed since the spec was proved).
+
+Staleness is structural, not heuristic: a stale spec's pass/fail verdict (Phase 3) no longer describes the code the user is shipping.
+
+### 2b — Coverage drift (new uncovered functions)
+
+Re-run `/specify`'s Phase 1 discovery (the visibility regex in `specify/references/spec-patterns.md` §1) over current source → the set of externally-reachable functions (`public` non-package + `entry`). Compare to the manifest's specified set:
+
+- A current function with **no spec** → **uncovered** (likely added since `/specify` ran). Report it and **point the user at `/specify`** to author a spec — `/verify` never writes one.
+- A manifest spec whose target no longer exists in source → **orphaned** (function renamed/removed). Report it; the spec is dead.
+
+### 2c — Context drift (reproducibility)
+
+Compare current environment to the manifest:
+
+- **Toolchain**: `binary.version` and the Sui/Boogie/Z3 versions from Phase 0 vs `toolchain`. A prover-version change can flip a proof — warn.
+- **Deps**: each `git_dependencies` rev vs the manifest's `deps[].rev`. A moved dep changes what called functions do; mid-flight upstream drift silently invalidates proofs (design doc Q4). Warn per changed dep; a dep `pinned_to_branch` is a standing warning regardless.
+
+## Phase 3 — Re-prove
+
+For each spec package in scope (respecting `--package`):
+
+1. `mcp__sui-prover__prove_package` with `move_toml_path` at the spec package and `extra_args` set to that package's manifest `flags` (e.g. `["--no-bv-int-encoding"]` for a `_bv` package). No `target_function` — verify the whole package in one run unless iterating a single failure.
+2. Trust `summary.overall` (`verified_all` / `failed_some` / `no_specs` / `compile_failure` / `timeout` / `error`) as the verdict. Collect per-spec `findings[]`.
+3. On `compile_failure` / `timeout` / `error`, consult the shared `failure-taxonomy.md`. `/verify` does **not** auto-tune `boogie_opt` or rewrite specs to chase a green — that is authoring. It reports the failure and, for a timeout, surfaces the taxonomy's escalation as a *suggestion to run `/specify`*.
+
+## Phase 4 — Classify every spec into a verdict bucket
+
+Join each spec's Phase 3 prover result with its Phase 2a freshness. This join is the whole point — it turns two booleans into an actionable verdict:
+
+| Source (2a) | Prover (3) | Verdict | Meaning / action |
+|---|---|---|---|
+| fresh | verified | **holds** | Guarantee intact against current code. |
+| fresh | failed | **violated** | Real regression — code changed elsewhere (or a dep moved) and now breaks a still-valid spec. Highest-signal finding; investigate the code, not the spec. |
+| stale | verified | **stale-passing** | Spec passes but describes *old* code. The pass is not a guarantee about what ships — re-run `/specify` to rebind, or confirm the change is spec-irrelevant. |
+| stale | failed | **stale-failing** | Source changed and the spec no longer holds. Expected after a refactor; re-author via `/specify`. |
+| (no spec) | — | **uncovered** | New externally-reachable function (2b) — needs `/specify`. |
+| (orphaned) | — | **orphaned** | Spec targets a function that no longer exists (2b) — dead spec. |
+
+The design's feedback loop (Q4 insight): a **violated** verdict means *"you broke a property you committed to"*; an **uncovered** verdict means *"you entered territory the specs never described."* Different failures, different fixes — name which one each spec is.
+
+## Phase 5 — Report and exit
+
+1. **HTML report** at `--report` path (default `.verify-report.html`) — self-contained semantic HTML5, inline CSS, house style matching `docs/*.html`. Sections: verdict summary (counts per bucket), the holds/violated/stale table, context-drift warnings (toolchain + deps), coverage drift (uncovered + orphaned), and a "next steps" block routing each non-`holds` verdict to its fix (`/specify` for stale/uncovered, code investigation for violated).
+2. **Refresh `/specify`'s report badges (if present).** If `.specify-report.html` (or per-module `*.spec.html`) exists, update only its `specify:auto:freshness` / drift-badge zones to reflect current verdicts — never touch `specify:human:*` zones. This keeps the authored report's staleness badges live.
+3. **Chat summary** — one screen: "N specs: H hold, V violated, S stale, U uncovered. Context: <toolchain/dep drift one-liner>. Report at `<path>`."
+4. **Exit semantics.**
+   - Default (warn-and-run): exit zero unless a spec **hard-fails to prove** (`failed_some` / `compile_failure` / `error`). Staleness and coverage gaps are warnings.
+   - `--strict` (CI): exit **non-zero** on *any* of — a spec failure, *any* stale spec, *any* uncovered function, missing spec package, or context drift (moved dep / changed prover version). CI must catch "the proof is no longer about the current code," not just "a spec failed."
+
+## Resumability & idempotency
+
+`/verify` holds no per-run state of its own — it is a pure function of (current source + spec packages + manifest). Re-running it is always safe and always recomputes from scratch. The only artifacts it writes are the report and (optionally) refreshed badges in `/specify`'s report. It never edits source, specs, or `Move.toml`.
+
+## Operating rules
+
+- **Read-mostly. Never author, edit, or delete a spec.** When `/verify` finds an uncovered function or a stale/failing spec that needs new clauses, it routes the user to `/specify` — it does not write the spec itself. This is the load-bearing boundary between the two skills.
+- **Never edit any `Move.toml`** — neither the production package's nor a spec package's.
+- **Never auto-tune to force green.** `boogie_opt`, `--split-paths`, `no_opaque`, prelude axioms are authoring decisions (they change what is being proved); `/verify` reports the failure and defers to `/specify`.
+- **`--strict` is the CI contract.** Refuse-on-drift, non-zero exit. Keep its triggers (failure / stale / uncovered / context drift / missing package) stable so the emitted `prover.yml` stays meaningful.
+- **Mirror the manifest's hash method exactly** in Phase 2a — a mismatched method manufactures false drift and destroys trust in the freshness signal.
+- **Degraded mode is honest, not silent.** With no manifest, announce that drift detection is off and recommend `/specify` to mint one; still re-prove and report verdicts.
+- **For document deliverables outside chat, prefer self-contained HTML** — the verify report is the user's record.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -23,7 +23,7 @@ A spec is a claim of the form *"this code, at this state, against these deps, sa
 
 ## Flags
 
-- `--strict` — **refuse-on-drift, CI posture.** Any staleness, context drift, coverage gap, or spec failure makes `/verify` exit non-zero. This is exactly what the `prover.yml` stub `/specify --audit` emits runs. Default (no flag) is **warn-and-run**: report everything, exit zero unless a spec hard-fails.
+- `--strict` — **refuse-on-drift, CI posture.** Any staleness, context drift, coverage gap, or spec failure makes `/verify` exit non-zero. This is exactly what the `prover.yml` stub that `/specify --audit` emits runs. Default (no flag) is **warn-and-run**: report everything, exit zero unless a spec hard-fails.
 - `--report <path>` — where to write the HTML report (default `.verify-report.html` at the package root).
 - `--package <name>` — verify only one spec package (e.g. `<pkg>_specs_bv`); default verifies all packages in the manifest.
 
@@ -41,6 +41,7 @@ Same hard gate as `/specify` Phase 0 — do not duplicate the logic, follow it:
 2. Parse the manifest: `production_package.source_hashes` (per `<mod>::<fn>`), `hash_method`, `spec_packages[]` (name + `flags`), `deps[]` (name + rev + `pinned_to_branch`), `toolchain`.
 3. Resolve each spec package directory on disk. If a manifest-listed spec package is missing, that is itself drift — record it and (in `--strict`) fail.
 4. `mcp__sui-prover__list_specs` on each spec package → the live set of `#[spec(...)]` twins and their `target =` mappings. Cross-check against the manifest's specified set (feeds Phase 2b).
+5. **No specs at all → nothing to verify.** If `list_specs` returns no `#[spec(prove)]` twins across all packages *and* the manifest (or degraded discovery) records none, report "no specs to verify" and exit cleanly — **zero exit even under `--strict`** (absence of specs is not drift). The exception is a manifest that *claims* specs which are now missing — that is caught as a missing-package (step 3) or orphaned spec (Phase 2b) and does fail under `--strict`.
 
 ## Phase 2 — Detect drift
 
@@ -50,7 +51,7 @@ Three independent drift axes. Collect all; don't short-circuit.
 
 For each `<mod>::<fn>` with a bound hash in the manifest:
 
-1. Recompute the current hash **using the manifest's `hash_method`** (bytecode hash if it says `bytecode`, else normalized-source hash — strip comments/whitespace over the function span). Mirroring the method is essential; a different method produces false drift.
+1. Recompute the current hash **using the exact recipe `/specify` Phase 5.1 defines** for the manifest's `hash_method` (the recipe — hash function, byte source, normalization — is specified there so author and verifier produce identical digests). Mirroring it byte-for-byte is essential; any deviation manufactures false drift.
 2. Compare to the bound hash. Equal → **fresh**. Different → **stale** (the production function changed since the spec was proved).
 
 Staleness is structural, not heuristic: a stale spec's pass/fail verdict (Phase 3) no longer describes the code the user is shipping.
@@ -67,7 +68,7 @@ Re-run `/specify`'s Phase 1 discovery (the visibility regex in `specify/referenc
 Compare current environment to the manifest:
 
 - **Toolchain**: `binary.version` and the Sui/Boogie/Z3 versions from Phase 0 vs `toolchain`. A prover-version change can flip a proof — warn.
-- **Deps**: each `git_dependencies` rev vs the manifest's `deps[].rev`. A moved dep changes what called functions do; mid-flight upstream drift silently invalidates proofs (design doc Q4). Warn per changed dep; a dep `pinned_to_branch` is a standing warning regardless.
+- **Deps**: each `git_dependencies` entry's rev vs the manifest `deps[]` entry of the same `name`. A moved dep changes what called functions do; mid-flight upstream drift silently invalidates proofs (design doc Q4). Warn per changed dep; a dep `pinned_to_branch` is a standing warning regardless.
 
 ## Phase 3 — Re-prove
 


### PR DESCRIPTION
## Summary

Reworks `/specify` and adds its companion `/verify`, folding in nine learnings mined from a real audit-grade Sui-Prover engagement (Asymptotic × Bluefin's formally-verified `integer-library`, the FV fork of integer-mate that re-proved the Cetus bug and found a new signed-`sub` bug).

**`/specify` redesign** (`skills/specify/SKILL.md` + references):
- **Separate spec package is now the default** — specs go in a sibling `<pkg>_specs/` package via `#[spec(prove, target = …)]`, keeping production source pristine. `--inline` is the opt-out.
- **Abort conditions** are a first-class, ask-first output (for math kernels the abort contract *is* the security property).
- **`Integer` math-domain modeling idiom** for custom numeric types (model once, `use fun` aliases).
- **Defining-property postconditions** over recompute-and-compare (e.g. `result*d <= p < (result+1)*d`).
- **Per-package prover flags**; a lazy `<pkg>_specs_bv/` package for bit-exact specs needing `--no-bv-int-encoding`.
- **`spec-context.json` reproducibility manifest** (per-fn source hashes + method, dep pins, toolchain, per-package flags).
- **Invariant-driven report** with auto/human markers and a **"Trusted axioms — not proved"** disclosure.
- `--audit` emits counterexample regression artifacts + a `prover.yml` CI stub.

**`/verify` (new)** — the read-mostly consumer half of the split:
- Reads `spec-context.json`; detects drift on three axes (source-hash freshness, coverage = uncovered/orphaned fns, toolchain/dep reproducibility).
- Re-proves each spec package with its recorded flags, then joins prover-result × freshness into verdict buckets: **holds / violated / stale-passing / stale-failing / uncovered / orphaned**.
- `--strict` is the CI posture (refuse-on-drift, non-zero exit) — the contract the emitted `prover.yml` targets. Degrades gracefully when no manifest exists.
- Hard boundary: never authors/edits/auto-tunes specs — routes back to `/specify`. Reuses `specify/references/failure-taxonomy.md`.

Design rationale and the full learnings analysis live in local working docs (`docs/*` is gitignored) and aren't part of this diff.

## Test plan

- [ ] Run `/specify` on a small package — confirm it scaffolds `<pkg>_specs/`, leaves production source untouched, and emits `spec-context.json` + an invariant-driven report.
- [ ] Run `/verify` against it — fresh specs report `holds`; mutate a production fn and confirm the bound spec flips to `stale`/`violated`.
- [ ] Confirm `/verify` degraded mode works on a manifest-less package (e.g. integer-library).
- [ ] Validate the full redesign against the Aftermath AMM eval (the 12 findings).
- [ ] Skill descriptions trigger correctly on `/specify` and `/verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)