### PR TITLE
feat(agent): add SendMessage tool to sui-pilot-agent

### DIFF
--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -10,6 +10,7 @@ tools:
   - MultiEdit
   - Write
   - Bash
+  - SendMessage
   - mcp__move-lsp__move_diagnostics
   - mcp__move-lsp__move_hover
   - mcp__move-lsp__move_completions


### PR DESCRIPTION
## What

Adds `SendMessage` to the `sui-pilot-agent` tools allowlist in `agents/sui-pilot-agent.md`.

## Why

Enables the sui-pilot-agent to coordinate with other agents via peer-to-peer messaging during multi-agent workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)