### PR TITLE
docs: update bundled-doc counts after weekly refresh (753 → 772)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ Always search and read these docs before writing code for these ecosystems.
 
 | Topic | Directory | Files |
 |---|---|---|
-| Sui blockchain, objects, transactions, DeFi, framework | `.sui-docs/` | 369 |
+| Sui blockchain, objects, transactions, DeFi, framework | `.sui-docs/` | 374 |
 | Move language tutorial + reference: syntax, types, abilities, idioms | `.move-book-docs/` | 145 |
-| Walrus storage, blobs, Sites, operators | `.walrus-docs/` | 86 |
-| Seal secrets, encryption, key servers, access control | `.seal-docs/` | 14 |
-| TypeScript SDK, dapp-kit, React hooks, kiosk, payment-kit | `.ts-sdk-docs/` | 115 |
+| Walrus storage, blobs, Sites, operators | `.walrus-docs/` | 93 |
+| Seal secrets, encryption, key servers, access control | `.seal-docs/` | 15 |
+| TypeScript SDK, dapp-kit, React hooks, kiosk, payment-kit | `.ts-sdk-docs/` | 121 |
 | Sui Prover: formal verification, `#[spec(prove)]`, Boogie tuning | `.sui-prover-docs/` | 24 |
 | Nautilus off-chain compute, TEE enclaves, attestation, PCRs, on-chain verification | `.sui-docs/sui-stack/nautilus/` | 8 |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > A Claude Code plugin that turns Claude into a Sui/Move development expert — grounded in current docs, not stale training data.
 
-sui-pilot bundles **753 documentation files** from six upstream MystenLabs corpora, a **Move LSP** bridge for real-time diagnostics, a **formal verification** wrapper for the Sui Prover, and **five specialized skills** — all wired into a doc-first agent that reads the docs before writing code. Install it and every Sui/Move question Claude answers is grounded in the current state of the ecosystem.
+sui-pilot bundles **772 documentation files** from six upstream MystenLabs corpora, a **Move LSP** bridge for real-time diagnostics, a **formal verification** wrapper for the Sui Prover, and **five specialized skills** — all wired into a doc-first agent that reads the docs before writing code. Install it and every Sui/Move question Claude answers is grounded in the current state of the ecosystem.
 
 **[Read the full story](https://contract-hero.github.io/sui-pilot/)**
 
@@ -14,18 +14,18 @@ sui-pilot bundles **753 documentation files** from six upstream MystenLabs corpo
 
 ## What Ships
 
-### Bundled documentation (753 files, 6 corpora)
+### Bundled documentation (772 files, 6 corpora)
 
 All docs are local and searchable. Claude reads them before generating code — no hallucinated APIs, no deprecated patterns.
 
 | Source | Files | Topics |
 |---|---|---|
-| **Sui** | 369 | Blockchain, objects, transactions, DeFi, framework |
+| **Sui** | 374 | Blockchain, objects, transactions, DeFi, framework |
 | **Move Book** | 145 | Move language tutorial + reference: syntax, types, abilities, idioms |
-| **TS SDK** | 115 | TypeScript SDK, dapp-kit, payment-kit, kiosk, React hooks |
-| **Walrus** | 86 | Decentralized blob storage, Walrus Sites, HTTP API |
+| **TS SDK** | 121 | TypeScript SDK, dapp-kit, payment-kit, kiosk, React hooks |
+| **Walrus** | 93 | Decentralized blob storage, Walrus Sites, HTTP API |
 | **Sui Prover** | 24 | Formal verification: `#[spec(prove)]` specs, Boogie tuning |
-| **Seal** | 14 | Secrets management, encryption, key servers, access control |
+| **Seal** | 15 | Secrets management, encryption, key servers, access control |
 
 ### MCP tools
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>sui-pilot — a Claude Code plugin for Sui/Move development</title>
-  <meta name="description" content="A Claude Code plugin that turns Claude into a Sui/Move development expert. 753 bundled docs, Move LSP integration, formal verification, and five specialized skills.">
+  <meta name="description" content="A Claude Code plugin that turns Claude into a Sui/Move development expert. 772 bundled docs, Move LSP integration, formal verification, and five specialized skills.">
   <style>
     :root {
       --bg: #fafaf7;
@@ -373,7 +373,7 @@
         <span class="eyebrow">Claude Code Plugin</span>
         <h1>Turn Claude into a <em>Sui/Move expert</em> &mdash; grounded in current docs.</h1>
         <p class="lede">
-          sui-pilot bundles 753 documentation files from six MystenLabs corpora, bridges the Move LSP
+          sui-pilot bundles 772 documentation files from six MystenLabs corpora, bridges the Move LSP
           and Sui Prover into Claude Code, and ships five specialized skills &mdash; all behind a
           doc-first agent that reads the docs before writing code. No hallucinated APIs, no deprecated
           patterns, no stale training data.
@@ -449,7 +449,7 @@
 
             <rect x="80" y="214" width="180" height="64" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
             <text x="170" y="238" font-size="13" font-weight="600" text-anchor="middle" font-family="system-ui" fill="#0f172a">Doc corpora</text>
-            <text x="170" y="256" font-size="11" text-anchor="middle" font-family="system-ui" fill="#475569">753 files &middot; 6 sources</text>
+            <text x="170" y="256" font-size="11" text-anchor="middle" font-family="system-ui" fill="#475569">772 files &middot; 6 sources</text>
             <text x="170" y="270" font-size="11" text-anchor="middle" font-family="system-ui" fill="#475569">Glob/Grep navigated</text>
 
             <rect x="270" y="214" width="140" height="64" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
@@ -487,12 +487,12 @@
           Six corpora synced from the official MystenLabs repos. Local, searchable, always current.
         </p>
         <div class="corpus-grid">
-          <div class="corpus-item"><strong>Sui</strong> <span>369 files &mdash; blockchain, objects, transactions, DeFi</span></div>
+          <div class="corpus-item"><strong>Sui</strong> <span>374 files &mdash; blockchain, objects, transactions, DeFi</span></div>
           <div class="corpus-item"><strong>Move Book</strong> <span>145 files &mdash; language tutorial, syntax, types, abilities</span></div>
-          <div class="corpus-item"><strong>TS SDK</strong> <span>115 files &mdash; TypeScript SDK, dapp-kit, React hooks</span></div>
-          <div class="corpus-item"><strong>Walrus</strong> <span>86 files &mdash; blob storage, Walrus Sites, HTTP API</span></div>
+          <div class="corpus-item"><strong>TS SDK</strong> <span>121 files &mdash; TypeScript SDK, dapp-kit, React hooks</span></div>
+          <div class="corpus-item"><strong>Walrus</strong> <span>93 files &mdash; blob storage, Walrus Sites, HTTP API</span></div>
           <div class="corpus-item"><strong>Sui Prover</strong> <span>24 files &mdash; formal verification, specs, Boogie</span></div>
-          <div class="corpus-item"><strong>Seal</strong> <span>14 files &mdash; secrets, encryption, key servers</span></div>
+          <div class="corpus-item"><strong>Seal</strong> <span>15 files &mdash; secrets, encryption, key servers</span></div>
         </div>
 
         <h3 style="margin-top: 40px; margin-bottom: 8px; font-size: 18px;">MCP tools</h3>


### PR DESCRIPTION
The 2026-07-06 upstream docs refresh (#36) changed the per-corpus file counts, leaving the README's *Bundled documentation* section (and its two siblings) stale. This updates all three places the counts appear: `README.md`, `CLAUDE.md`, and `site/index.html`.

| Corpus | Old | New |
|---|---|---|
| Sui | 369 | **374** |
| Move Book | 145 | 145 |
| TS SDK | 115 | **121** |
| Walrus | 86 | **93** |
| Sui Prover | 24 | 24 |
| Seal | 14 | **15** |
| **Total** | **753** | **772** |

Counting methodology matches the original figures (verified against commit f135c91 where 753 was introduced): `.md`/`.mdx` files per corpus, and for `.sui-prover-docs` all files except `LICENSE` and `Move.lock` (the `.move` sources are content there). Nautilus subset in CLAUDE.md is unchanged at 8.

Note: these numbers will drift again with every weekly refresh — a follow-up could make `scripts/sync-sui-pilot-docs.sh` regenerate them automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Len1GGh7cpBFcoV1i7vBAG