### PR TITLE
fix(graph): correct confirmed falsehoods in the knowledge graph

### DIFF
--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -318,12 +318,16 @@ runtime checks. The toolkit below is what idiomatic Sui packages use to express
 pattern that expresses your intent.
 
 ```
-AUTHORIZATION                         📖 docs: .move-book-docs/book/programmability/authorization-patterns.md
+AUTHORIZATION                         📖 docs: .sui-docs/develop/security/best-practices.mdx (§ Access control)
+│   (the Move Book authorization-patterns.md index is currently empty — route to the
+│    per-pattern chapters below)
 │
 ├── Capability                        📖 docs: .move-book-docs/book/programmability/capability.md
 │   → owning a `XxxCap` object proves the right to perform privileged ops
 │   ↔ TreasuryCap<T>, UpgradeCap, Publisher are the canonical examples
-│   ⊃ Object capability — capability *is* the object, not a field of it
+│   ⊃ capabilities ARE objects (capability.md § "Capability is an Object");
+│     common DeFi caps: PoolAdminCap, OracleSourceCap, BridgeOperatorCap
+│   ⚠ anti-pattern: tx_context::sender() as the only guard — use a Capability
 │   ⤳ skill: move-code-review (assert holder; never accept by-ref a cap from untrusted caller)
 │   ⇢ alternative: address allowlist when multiple operators rotate frequently
 │
@@ -340,27 +344,25 @@ AUTHORIZATION                         📖 docs: .move-book-docs/book/programmab
 │   ↔ coin::create_currency<T>(otw, ...)
 │
 ├── Hot potato pattern                📖 docs: .move-book-docs/book/programmability/hot-potato-pattern.md
-│   → struct WITHOUT drop ability; caller MUST consume via specific function
+│   → struct with NO abilities at all (a no-drop-but-store struct could be stashed); caller MUST consume via specific function
 │   ↔ flash loans, transient receipts, in-progress trade objects
+│   ↔ framework hot potatoes: transfer_policy::TransferRequest, token::ActionRequest
 │   ⤳ skill: move-code-review (every hot-potato needs an exhaustive consume function)
 │   ⇢ alternative: Option-wrapped builder when the consume step is optional
 │
-├── Publisher                         📖 docs: .move-book-docs/book/programmability/publisher.md
-│   → struct evidencing original package authorship (`from_package<T>(pub)` at OTW init)
-│   ↔ Display, transfer-policy: gated by Publisher
-│   ⤳ skill: move-code-quality (idiomatic packages own a Publisher per type family)
-│
-└── Object capability                 📖 docs: .move-book-docs/book/programmability/object-capability.md
-    → cap is itself a `key`-able object, not just a struct field
-    ↔ Address-owned ownership keeps the cap isolated to one user
-    ⊃ Common in DeFi: PoolAdminCap, OracleSourceCap, BridgeOperatorCap
+└── Publisher                         📖 docs: .move-book-docs/book/programmability/publisher.md
+    → struct evidencing package authorship; claimed via `package::claim(otw, ctx)` in init
+    → authority checked later via `from_module<T>(&pub)` / `from_package<T>(&pub)` —
+      every gated function must perform the check (publisher.md security warning)
+    ↔ Display, transfer-policy: gated by Publisher
+    ⤳ skill: move-code-quality (idiomatic packages own a Publisher per type family)
 ```
 
 **When to use what — quick decision flow:**
 
 - Need to gate a function on caller identity, no transferable proof? → **Witness**
 - Privileged op tied to a one-shot module init? → **OTW**
-- Privileged op tied to a transferable, long-lived role? → **Capability** (probably Object Capability)
+- Privileged op tied to a transferable, long-lived role? → **Capability**
 - Caller must complete a multi-step protocol or pay/refund? → **Hot potato**
 - Authorship-of-a-package check (Display/policy ops)? → **Publisher**
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -110,6 +110,7 @@ If `move-analyzer` is not available, continue without MCP tools and note that la
 - `⊃ contains` — parent/child or whole/part relationship
 - `⤳ skill:` — pointer to a bundled skill that provides actionable guidance
 - `📖 docs:` — entry point in the bundled corpora (search root: `${CLAUDE_PLUGIN_ROOT}/.<source>-docs/`)
+- `⚠ warning` — a foot-gun or anti-pattern to avoid
 
 Cross-reference sections by `Glob`/`Grep` when an edge suggests you should — this map orients,
 the corpora are authoritative.

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -127,21 +127,29 @@ on-chain object. Mismatched abilities are a compile-time error, not a runtime ch
 ABILITIES                             📖 docs: .move-book-docs/book/move-basics/abilities-introduction.md
 │
 ├── copy   — value can be duplicated (`let b = a;` doesn't move)
+│   📖 docs: .move-book-docs/book/move-basics/copy-ability.md
 │   ↔ drop  — usually paired; `copy + drop` ≈ "plain old data"
 │   ⇢ alternative: pass by reference (`&T`) when the value is expensive
 │
 ├── drop   — value can be silently dropped at end of scope
-│   ↔ Hot-potato pattern → values WITHOUT drop force the caller to consume them
+│   📖 docs: .move-book-docs/book/move-basics/drop-ability.md
+│   ↔ Hot-potato pattern → a struct with NO abilities must be consumed explicitly
 │   ⤳ skill: move-code-review (hot-potato is a load-bearing safety pattern)
 │
-├── key    — value may be stored as a top-level Sui object (requires UID as first field)
+├── key    — value may be stored as a top-level Sui object
+│   📖 docs: .move-book-docs/book/storage/key-ability.md
+│   → verifier rules: first field must be `id: UID`; all other fields need `store`;
+│     key types can never have `copy` or `drop` (bound `T: copy` excludes objects)
 │   → Sui object model § UID/ID
 │   ↔ store — `key + store` is the standard "owned object" combo
-│   ⊃ marker for `transfer::*` family (transfer/share/freeze/wrap)
+│   ⊃ transfer ops: transfer, share_object, freeze_object, party_transfer, receive
+│     (`public_*` variants additionally require `store`)
+│     📖 docs: .move-book-docs/book/appendix/transfer-functions.md
 │
-└── store  — value may be embedded inside another object's fields
+└── store  — value may be embedded inside another object's fields; also the "public
+    modifier" that unlocks `public_transfer`/`public_share_object`/wrapping
+    📖 docs: .move-book-docs/book/storage/store-ability.md
     → key   — store-only (no key) types are fields, not standalone objects
-    ⇢ alternative: `Option<T>` when the embedded value may be absent
 ```
 
 **Generics & phantom types**
@@ -168,20 +176,22 @@ REFERENCES                            📖 docs: .move-book-docs/book/move-basic
 │
 ├── &T   immutable borrow — read-only, multiple coexist
 ├── &mut T mutable borrow — exclusive, no aliasing
-└── Ownership rules
+└── Ownership rules                   📖 docs: .move-book-docs/book/move-basics/ownership-and-scope.md
     ├── A function consuming a value by-move destroys the caller's binding
     ├── References cannot outlive their referent — borrow-checker enforced
     └── No `Drop`-equivalent destructor; types lacking `drop` MUST be consumed explicitly
         ⤳ skill: move-code-review (look for unconsumed hot-potatoes & resource leaks)
 ```
 
-**Move 2024 idioms** that the agent should *prefer over their pre-2024 equivalents*:
+**Move 2024 idioms** that the agent should *prefer over their pre-2024 equivalents*
+(📖 docs: .move-book-docs/book/guides/code-quality-checklist.md):
 
 - `module x::y;` (file-level form) over `module x::y { ... }`
 - Method-call syntax: `v.push_back(x)` over `vector::push_back(&mut v, x)`
 - Macros: `vector::do!`, `vector::fold!`, `option::destroy!` over hand-written loops
 - Implicit framework dependencies (Sui 1.45+) — drop explicit `Sui = { ... }` from `Move.toml` unless pinning a non-default version
 - `assert!(cond, code)` with named error constants — never magic numbers
+- `#[error]` const of `vector<u8>` for human-readable abort messages (Move 2024)
 - `package::Type::method(...)` qualified calls when the receiver is ambiguous
 
 ⤳ skill: move-code-quality (the canonical checklist for these)

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -240,16 +240,17 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 ├── UID (globally unique, 32-byte) — required first field of any `key`-able struct
 │   → Move type system § ABILITIES (key requires UID)
 │   ↔ object::new(ctx)               → construct fresh UID (consumes a counter)
-│   ↔ object::delete(uid)            → destroy when wrapping/unwrapping
+│   ↔ object::delete(uid)            → destroy an object (ID is retained across wrap/unwrap)
 │
 ├── Object ownership                  📖 docs: .sui-docs/develop/objects/object-ownership/
 │   ├── Address-owned                 ⤳ skill: move-code-review
 │   │   → fast-path execution; one writer at a time; no consensus needed
+│   │   → docs now recommend Party over fastpath for owned objects (versioning.mdx tip)
 │   │   ⇢ alternative: shared (when multi-writer is required)
 │   │
 │   ├── Shared                        → consensus-required; multi-writer; congestion-prone
 │   │   ⤳ skill: move-code-review (look for shared-object hot spots)
-│   │   ↔ Party objects               → opt-in shared ownership with explicit allowed-writer set
+│   │   ⇢ alternative: Party objects  → single-owner, consensus-sequenced (see below)
 │   │   ⇢ alternative: derived objects (parent-child) when ownership is hierarchical
 │   │
 │   ├── Immutable (frozen)            → freeze_object(); read-only by anyone
@@ -259,8 +260,11 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 │   │   → Move type system § store ability
 │   │   ↔ ParentObject { child: Child } pattern
 │   │
-│   └── Party                         📖 docs: .sui-docs/develop/objects/object-ownership/party.mdx
-│       → bounded-writer-set shared object; cheaper than full shared
+│   └── Party (ConsensusAddressOwner) 📖 docs: .sui-docs/develop/objects/object-ownership/party.mdx
+│       → single-address ownership sequenced by consensus; enables many concurrent
+│         inflight txns on one owned object (multi-member parties planned, not shipped)
+│       → created via transfer::party_transfer + sui::party::single_owner(addr)
+│       → caveat: a party Coin<SUI> cannot pay gas; docs recommend party over fastpath
 │
 ├── Dynamic fields                    📖 docs: .sui-docs/develop/objects/dynamic-fields.mdx
 │   ⊃ dynamic_field    — heterogeneous typed children at arbitrary keys
@@ -269,9 +273,11 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 │   ⤳ skill: move-code-review (DOF lookups can hide gas costs; audit access patterns)
 │
 ├── Derived objects                   📖 docs: .sui-docs/develop/objects/derived-objects.mdx
-│   → object whose UID is deterministically derived from a parent UID + index
-│   ↔ replaces ad-hoc Table<address, Object> patterns
-│   ⊃ enables explicit parent-child ownership without dynamic fields
+│   → UID deterministically derived from (parent UID, key) — key need not be unique-typed
+│   → NOT children of the parent: independent top-level objects, so unrelated keys
+│     mutate in parallel (no parent sequencing bottleneck)
+│   ↔ replaces ad-hoc Table<address, Object> registry patterns
+│   ⊃ API: derived_object::claim / derive_address / exists
 │
 ├── Versioning                        📖 docs: .sui-docs/develop/objects/versioning.mdx
 │   ↔ Each mutation bumps the object version (used by consensus + replay)
@@ -282,7 +288,10 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
     ├── transfer::transfer(obj, addr)        → address-owned
     ├── transfer::share_object(obj)          → shared
     ├── transfer::freeze_object(obj)         → immutable
-    ├── transfer::public_transfer(obj, addr) → store-only types
+    ├── transfer::public_transfer(obj, addr) → `key + store` types, callable outside
+    │   the defining module (mirrors public_share_object / public_freeze_object)
+    ├── transfer::party_transfer(obj, party)  → party-owned (single_owner)
+    ├── transfer::receive(&mut parent.id, Receiving<T>) → transfer-to-object (TTO)
     └── ⤳ skill: move-code-review (blind transfers are a common SEC-AC bug class)
 ```
 
@@ -290,12 +299,12 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 
 | Use case | Pick | Why |
 |---|---|---|
-| User-owned NFT or coin | Address-owned | Fast path, no consensus, one user mutates |
+| User-owned NFT or coin | Address-owned (or Party — docs' newer recommendation) | Fast path; Party allows concurrent inflight txns |
 | Auction, AMM pool, registry | Shared | Multiple users mutate concurrently |
 | Configuration / on-chain constant | Immutable | Read-many, never write |
 | Inventory of children with shared state | Wrapped or DOF | Composition over reference |
-| Ordered collection at a parent | Derived objects | Deterministic addresses, no DOF gas |
-| Bounded multi-writer (committees, oracles) | Party | Cheaper than full shared, bounded set |
+| Registry / one-object-per-key slots (per-user config, soulbound) | Derived objects | Deterministic addresses, no parent bottleneck |
+| Owned object, many concurrent inflight txns | Party | Consensus versioning removes fastpath equivocation locks |
 
 ⤳ skill: move-code-review (the single most common review finding is "wrong ownership choice")
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -380,6 +380,7 @@ before reviewing any transaction-building code (Move side or TS SDK side).
 ```
 TRANSACTIONS                          📖 docs: .sui-docs/develop/transactions/index.mdx
 ├── PTB structure                     📖 docs: .sui-docs/develop/transactions/ptbs/
+├── Transaction lifecycle             📖 docs: .sui-docs/develop/transactions/transaction-lifecycle.mdx
 ├── Transaction auth                  📖 docs: .sui-docs/develop/transactions/transaction-auth/
 ├── Gas model                         📖 docs: .sui-docs/develop/transaction-payment/gas-in-sui.mdx
 ├── Sponsored / gasless txns          📖 docs: .sui-docs/develop/transaction-payment/sponsor-txn.mdx
@@ -399,7 +400,9 @@ hands. Kiosk is the canonical marketplace primitive built on top.
 ```
 TRANSFER POLICIES                     📖 docs: .sui-docs/develop/objects/transfers/
 ├── transfer-policies                 → declare rules; policy is `T`-typed
-├── custom-rules                      → royalties, allowlist, time-locks
+├── custom-rules                      → omit `store` so only the defining module can
+│                                       transfer the type (module-gated transfer fns)
+├── rule variants (in transfer-policies) → royalty rules, time-based rules, witness/capability rules
 ├── Kiosk                             📖 docs: .sui-docs/onchain-finance/kiosk/
 └── ⤳ skill: move-code-review
 ```
@@ -437,6 +440,8 @@ CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
 │
 ├── Randomness                        📖 docs: .sui-docs/sui-stack/on-chain-primitives/randomness-onchain.mdx
 │   → consensus-driven on-chain RNG via `sui::random::Random` shared object
+│   → public fns taking &Random are compiler-REJECTED — expose private `entry` only
+│   → divide-logic pattern: commit random result in tx1, consume in tx2 (revert griefing)
 │   ⤳ skill: move-code-review (never use timestamps, tx hash, or coin balances as randomness)
 │   ⇢ alternative: commit-reveal with off-chain entropy when external sources are required
 │
@@ -466,7 +471,12 @@ ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
 ├── Coin<T>, Balance<T>, TreasuryCap<T>  → standard fungible currency
 ├── Closed-loop tokens                   → permissioned movement, action-request rules
 ├── DeepBookV3 orderbook                 → permissionless / permissioned pools
-├── Fixed-point math                     → mul_div, rate calculations, share accounting
+├── Coin standards: legacy `coin::create_currency` ⇢ newer Currency Standard via
+│   `sui::coin_registry` (new_currency / new_currency_with_otw, MetadataCap, supply states)
+│   📖 docs: .sui-docs/onchain-finance/fungible-tokens/currency.mdx
+├── Fixed-point math                     → std::fixed_point32; per-type integer modules
+│   std::u8–u256 (max, diff, divide_and_round_up, sqrt, pow)
+│   📖 docs: .move-book-docs/book/move-basics/standard-library.md
 └── ⤳ skill: oz-math (math safety audit)
    ⤳ skill: move-code-review (overflow, rounding bias, MEV exposure)
 ```
@@ -545,12 +555,12 @@ Stub — flesh in v2 follow-up. The migration index is the load-bearing read her
 ```
 TOOLING
 ├── Sui CLI                           📖 docs: .sui-docs/references/cli/
-│   ⊃ sui client (network ops), sui move (build/test), sui keytool, sui ptb
+│   ⊃ sui client (network ops; `sui client ptb` for PTBs), sui move (build/test), sui keytool, sui replay
 ├── Move 2024 edition                 📖 docs: .move-book-docs/book/before-we-begin/move-2024.md
 │   ⤳ skill: move-code-quality
 ├── move-analyzer (LSP)               → MCP-bridged via plugin's move-lsp server
 │   ⊃ tools: move_diagnostics, move_hover, move_completions, move_goto_definition
-│   ⤳ skill: specify (LSP-driven spec authoring + verification)
+│   ⤳ skill: specify (spec authoring — driven by the sui-prover MCP server, not the LSP)
 └── sui-pilot plugin                  → this package; bundles all of the above
    ⤳ skill: move-code-review (security + architecture review)
 ```

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -200,18 +200,25 @@ REFERENCES                            📖 docs: .move-book-docs/book/move-basic
 
 ## Modules & visibility
 
-Modules are the unit of code organization, deployment, and visibility in Move.
+Modules are the unit of code organization and visibility in Move; packages are the
+unit of deployment (published on-chain at an address).
 Visibility ranges from private (default) → `public(package)` (intra-package) →
 `public` (cross-package callable). The `friend` keyword from pre-2024 Move is replaced
 by `public(package)` for the most common cases.
 
 ```
 MODULES                               📖 docs: .move-book-docs/book/move-basics/module.md
+├── ⊃ PACKAGE ⊃ modules               📖 docs: .move-book-docs/book/concepts/packages.md
 ├── module x::y;                      → file-level, Move 2024
 ├── public(package) fun ...           → callable only from same package
-├── public fun ...                    → callable from any package (entry points + library API)
-├── entry fun ...                     → callable as a transaction's top-level call
-└── #[allow(...)] / #[test_only]      → attribute-driven scope
+├── public fun ...                    → callable from any package AND from PTBs
+│   📖 docs: .move-book-docs/book/move-basics/visibility.md
+├── entry fun ...                     → PTB-callable but NOT callable from other packages
+│   (front-run-sensitive flows, e.g. randomness consumers — see § Cryptography)
+│   📖 docs: .sui-docs/develop/write-move/sui-move-concepts.mdx
+└── #[test_only] / #[mode(...)]       → compile-time inclusion filters; mode-annotated
+    code is unpublishable (#[test_only] = sugar for #[mode(test)])
+    📖 docs: .move-book-docs/book/move-advanced/modes.md
     ⤳ skill: move-code-quality
 ```
 

--- a/scripts/check-graph-pointers.sh
+++ b/scripts/check-graph-pointers.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Verify every "📖 docs:" pointer in the agent knowledge graph resolves to a
+# real file or directory in the bundled corpora. Exit 1 on any miss.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+FILE="${1:-agents/sui-pilot-agent.md}"
+fail=0
+while IFS= read -r p; do
+  # strip trailing punctuation the prose sometimes adds
+  p="${p%%,}"
+  p="${p%%)}"
+  if [ -e "$p" ]; then
+    echo "OK   $p"
+  else
+    echo "MISS $p"
+    fail=1
+  fi
+done < <(grep -oE '📖 docs: [^ ,)]+' "$FILE" | sed 's/📖 docs: //' | sort -u)
+exit $fail

--- a/scripts/check-graph-pointers.sh
+++ b/scripts/check-graph-pointers.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 FILE="${1:-agents/sui-pilot-agent.md}"
+[ -r "$FILE" ] || { echo "MISS: cannot read $FILE" >&2; exit 2; }
 fail=0
 while IFS= read -r p; do
   if [ -e "$p" ]; then

--- a/scripts/check-graph-pointers.sh
+++ b/scripts/check-graph-pointers.sh
@@ -6,9 +6,6 @@ cd "$(dirname "$0")/.."
 FILE="${1:-agents/sui-pilot-agent.md}"
 fail=0
 while IFS= read -r p; do
-  # strip trailing punctuation the prose sometimes adds
-  p="${p%%,}"
-  p="${p%%)}"
   if [ -e "$p" ]; then
     echo "OK   $p"
   else


### PR DESCRIPTION
Fixes the 20 confirmed defects (audit 2026-07-06, workflow wf_b52d00fb-f15) in sections not scheduled for rewrite. See knowledge-graph-audit.html for evidence. TS SDK/Walrus/Seal defects are fixed in the follow-up rewrite PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Len1GGh7cpBFcoV1i7vBAG