### PR TITLE
ci: knowledge-graph pointer freshness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check knowledge-graph doc pointers
+        run: ./scripts/check-graph-pointers.sh
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Pull upstream docs
         run: ./sync-docs.sh
 
+      - name: Check knowledge-graph doc pointers survive refresh
+        run: ./scripts/check-graph-pointers.sh
+
       - name: Skip bundler if nothing drifted
         id: drift
         # sync-sui-pilot-docs.sh always rewrites docs/VERSION.json with a fresh

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -30,6 +30,10 @@ jobs:
         run: ./sync-docs.sh
 
       - name: Check knowledge-graph doc pointers survive refresh
+        # Soft-warn here so a broken pointer does not suppress the whole refresh
+        # PR (which is what surfaces the drift). The PR's own CI run of this same
+        # script (ci.yml, pull_request) hard-fails and blocks the merge.
+        continue-on-error: true
         run: ./scripts/check-graph-pointers.sh
 
       - name: Skip bundler if nothing drifted


### PR DESCRIPTION
Runs scripts/check-graph-pointers.sh in CI and in the weekly docs refresh so upstream renames that break graph routing fail the PR instead of shipping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Len1GGh7cpBFcoV1i7vBAG