### PR TITLE
feat(graph): knowledge graph v2 — flesh stubs, add missing topics (terse routing)

### DIFF
--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -203,27 +203,32 @@ REFERENCES                            📖 docs: .move-book-docs/book/move-basic
 
 Modules are the unit of code organization and visibility in Move; packages are the
 unit of deployment (published on-chain at an address).
-Visibility ranges from private (default) → `public(package)` (intra-package) →
-`public` (cross-package callable). The `friend` keyword from pre-2024 Move is replaced
-by `public(package)` for the most common cases.
 
 ```
 MODULES                               📖 docs: .move-book-docs/book/move-basics/module.md
 ├── ⊃ PACKAGE ⊃ modules               📖 docs: .move-book-docs/book/concepts/packages.md
 ├── module x::y;                      → file-level, Move 2024
-├── public(package) fun ...           → callable only from same package
+├── use pkg::mod::{Self, Member}      → imports; only public/public(package) members are
+│   importable; `as` renames conflicts
+│   📖 docs: .move-book-docs/book/move-basics/importing-modules.md
+├── public(package) fun ...           → callable only from same package; replaces the
+│   deprecated `friend`/`public(friend)` (`sui move migrate` auto-rewrites)
+│   📖 docs: .move-book-docs/book/guides/2024-migration-guide.md
 ├── public fun ...                    → callable from any package AND from PTBs
 │   📖 docs: .move-book-docs/book/move-basics/visibility.md
+│   📖 docs: .move-book-docs/reference/functions.md (authoritative visibility semantics)
 ├── entry fun ...                     → PTB-callable but NOT callable from other packages
 │   (front-run-sensitive flows, e.g. randomness consumers — see § Cryptography)
 │   📖 docs: .sui-docs/develop/write-move/sui-move-concepts.mdx
+├── struct pack/unpack privilege      → construction, destruction, and field access stay
+│   internal to the defining module — the invariant behind witness & hot potato
+│   📖 docs: .move-book-docs/book/move-basics/struct.md
+│   → § Authorization patterns
 └── #[test_only] / #[mode(...)]       → compile-time inclusion filters; mode-annotated
     code is unpublishable (#[test_only] = sugar for #[mode(test)])
     📖 docs: .move-book-docs/book/move-advanced/modes.md
     ⤳ skill: move-code-quality
 ```
-
-Stub — flesh out further when chunk-extraction tests start asking for this section.
 
 ---
 
@@ -556,16 +561,31 @@ Stub — flesh in v2 follow-up. The migration index is the load-bearing read her
 ```
 TOOLING
 ├── Sui CLI                           📖 docs: .sui-docs/references/cli/
-│   ⊃ sui client (network ops; `sui client ptb` for PTBs), sui move (build/test), sui keytool, sui replay
-├── Move 2024 edition                 📖 docs: .move-book-docs/book/before-we-begin/move-2024.md
-│   ⤳ skill: move-code-quality
+│   ⊃ sui client (network ops; `sui client ptb` for PTBs), sui move (build/test/migrate),
+│     sui keytool, sui replay
+├── Move 2024 edition                 📖 docs: .move-book-docs/book/guides/2024-migration-guide.md
+│   ⤳ skill: move-code-quality       📖 docs: .move-book-docs/book/guides/code-quality-checklist.md
 ├── move-analyzer (LSP)               → MCP-bridged via plugin's move-lsp server
-│   ⊃ tools: move_diagnostics, move_hover, move_completions, move_goto_definition
-│   ⤳ skill: specify (spec authoring — driven by the sui-prover MCP server, not the LSP)
+│   ⊃ tools (10): move_diagnostics, move_hover, move_completions, move_goto_definition,
+│     move_find_references, move_rename, move_document_symbols, move_type_definition,
+│     move_code_actions, move_inlay_hints
+├── sui-prover (MCP)                  📖 docs: .sui-prover-docs/guide/
+│   ⊃ tools: prove_package, list_specs, prover_capabilities
+│   ⤳ skill: specify (author specs — driven by this MCP server, not the LSP) · ⤳ skill: verify
+│   → § Formal verification (Sui Prover)
+├── Debugging                         → `sui replay --digest <d> [--trace]` re-executes locally
+│   📖 docs: .sui-docs/references/cli/replay.mdx
+│   ⊃ Move Trace Debugger (VS Code)   📖 docs: .sui-docs/references/ide/debugger.mdx
+│   ⊃ trace analysis (gas profiling)  📖 docs: .sui-docs/references/cli/trace-analysis.mdx
+├── Testing & troubleshooting         📖 docs: .sui-docs/develop/testing-debugging/
+│   ⊃ testing.mdx, common-errors.mdx (tx/object/package error triage)
+│   ↔ § Testing Move packages
+├── Package management (new system, Sui CLI 1.63+)
+│   📖 docs: .sui-docs/references/package-managers/manifest-reference.mdx
+│   ⊃ `git` / `local` / `r.mvr` (Move Registry) deps; [addresses] section removed
+│   ⊃ migration guide                 📖 docs: .sui-docs/references/package-managers/package-manager-migration.mdx
 └── sui-pilot plugin                  → this package; bundles all of the above
-   ⤳ skill: move-code-review (security + architecture review)
+    ⤳ skill: move-code-review (security + architecture review)
 ```
 
-Stub — flesh in v2 follow-up. The LSP integration is the single most useful tool for
-the agent's day-to-day Move editing; prefer `move_diagnostics` over re-running
-`sui move build` for tight iteration loops.
+Prefer `move_diagnostics` over re-running `sui move build` for tight iteration loops.

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -663,26 +663,52 @@ SEAL                                  📖 docs: .seal-docs/index.mdx → .seal-
 
 ## TypeScript SDK & 2.0 migration
 
-Any TypeScript code that imports `@mysten/*` should be assumed potentially on the
-1.x API; SDK 2.0 (March 2026) introduces breaking changes that pre-cutoff training
-data does not know. The 2.0 split client paths — `@mysten/sui/jsonRpc` vs.
-`@mysten/sui/grpc` — and removed several legacy helpers in favor of client-extension
-plug-ins.
+Any TypeScript code importing `@mysten/*` may still be on the 1.x API; SDK 2.0
+(current major) has extensive breaking changes pre-cutoff training does not know:
+packages are ESM-only, every client constructor requires an explicit `network`
+param, 1.x `SuiClient` is REMOVED, and `core.getObject` THROWS on missing objects
+(v1 returned `null`).
 
 ```
-TS SDK                                📖 docs: .ts-sdk-docs/sui/
-├── Clients                           → SuiJsonRpcClient, SuiGrpcClient (2.0)
-│   ⇢ alternative to: 1.x SuiClient (deprecated)
-├── Transactions builder              → tx, tx.moveCall, tx.transferObjects, ...
-├── BCS serialization                 → on-chain types via bcs.struct(...)
-├── dapp-kit (React)                  📖 docs: .ts-sdk-docs/dapp-kit/
-├── kiosk SDK
-├── payment-kit
-└── SDK 2.0 migration                 📖 docs: .ts-sdk-docs/sui/migrations/sui-2.0/
-   ⤳ Always read the 2.0 migration index when editing `@mysten/*` code
+TS SDK                                📖 docs: .ts-sdk-docs/sui/migrations/sui-2.0/index.mdx
+│
+├── Clients (3 transports)            📖 docs: .ts-sdk-docs/sui/clients/index.mdx
+│   ├── SuiGrpcClient (`@mysten/sui/grpc`) — recommended default
+│   ├── SuiGraphQLClient — advanced query patterns full nodes can't serve directly
+│   ├── SuiJsonRpcClient — deprecated, decommission pending; migrate to gRPC
+│   └── 1.x SuiClient — REMOVED in 2.0 (not merely deprecated)
+│
+├── Core API — `client.core` / ClientWithCoreApi, transport-agnostic common ops
+│   📖 docs: .ts-sdk-docs/sui/clients/core.mdx
+│   ⊃ `$extend(...)` client extensions — walrus, seal, kiosk, suins, deepbook-v3,
+│     zksend all ship as extensions
+│
+├── Transactions builder              📖 docs: .ts-sdk-docs/sui/transactions/
+│   ⊃ Serial/ParallelTransactionExecutor — queue/parallelize same-sender txns,
+│     cache gas coins + object versions  📖 docs: .ts-sdk-docs/sui/executors.mdx
+│
+├── Signing — keypairs + external Signers (AWS/GCP KMS, Ledger, WebCrypto,
+│   passkey, multisig)                📖 docs: .ts-sdk-docs/sui/cryptography/signers/index.mdx
+│   ↔ Cryptography & primitives § Signing & verification
+│
+├── BCS — `bcs.struct(...)`           📖 docs: .ts-sdk-docs/bcs/index.mdx
+│   ⊃ Sui pre-defined schemas (`@mysten/sui/bcs`)  📖 docs: .ts-sdk-docs/sui/bcs.mdx
+│   ⇢ alternative: `@mysten/codegen` — typed bindings generated from Move packages
+│     (in development, may break)     📖 docs: .ts-sdk-docs/codegen/
+│
+├── dapp-kit                          📖 docs: .ts-sdk-docs/dapp-kit/index.mdx
+│   ├── @mysten/dapp-kit-core (framework-agnostic) + @mysten/dapp-kit-react (hooks)
+│   └── legacy @mysten/dapp-kit — deprecated, JSON-RPC-only, no gRPC/GraphQL ever
+│       📖 docs: .ts-sdk-docs/sui/migrations/sui-2.0/dapp-kit.mdx (migration guide)
+│
+├── kiosk SDK                         📖 docs: .ts-sdk-docs/kiosk/
+├── payment-kit                       📖 docs: .ts-sdk-docs/payment-kit/
+├── sponsor (experimental incubation) 📖 docs: .ts-sdk-docs/sponsor/
+└── zksend claim links                📖 docs: .ts-sdk-docs/zksend/
 ```
 
-Stub — flesh in v2 follow-up. The migration index is the load-bearing read here.
+⤳ Always read the 2.0 migration index when editing `@mysten/*` code — it is the
+load-bearing read; per-package guides live beside it.
 
 ---
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -316,7 +316,7 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 ├── Events                            📖 docs: .move-book-docs/book/programmability/events.md
 │   → sui::event::emit<T: copy + drop>(event); verifier requires T internal to the emitting module
 │   → stored in transaction effects, not on-chain state; sender + timestamp come free in metadata
-│   ↔ § Accessing on-chain data (query/index)  ↔ TS SDK (event queries)
+│   ↔ § Accessing on-chain data (query/index)  ↔ TS SDK § Clients (event queries)
 │
 └── Transfer functions                📖 docs: .move-book-docs/book/appendix/transfer-functions.md
     ├── transfer::transfer(obj, addr)        → address-owned
@@ -609,7 +609,7 @@ WALRUS                                📖 docs: .walrus-docs/system-overview/co
 │   ⚠ QuiltPatchId depends on whole-quilt composition (NOT content-derived);
 │     no per-item delete/extend/share — whole-quilt only
 ├── Roles: storage nodes / aggregators (+ caches) / publishers / upload relay
-│   → relay: one POST vs ≈2200 direct-SDK requests per write  📖 docs: .walrus-docs/system-overview/relay.mdx
+│   → relay: one POST vs ≈2200 direct-SDK requests per write  📖 docs: .ts-sdk-docs/walrus/index.mdx, .walrus-docs/system-overview/relay.mdx
 │   → node/publisher/aggregator ops  📖 docs: .walrus-docs/operator-guide/
 ├── walrus CLI (+ JSON mode)          📖 docs: .walrus-docs/walrus-client/
 ├── HTTP API (publisher/aggregator)   📖 docs: .walrus-docs/http-api/
@@ -674,8 +674,8 @@ TS SDK                                📖 docs: .ts-sdk-docs/sui/migrations/sui
 │   ↔ § Accessing on-chain data (gRPC/GraphQL read paths, event queries)
 ├── Core API — `client.core` / ClientWithCoreApi, transport-agnostic common ops
 │   📖 docs: .ts-sdk-docs/sui/clients/core.mdx
-│   ⊃ `$extend(...)` client extensions — walrus, seal, kiosk, suins, deepbook-v3,
-│     zksend all ship as extensions
+│   ⊃ `$extend(...)` client extensions — walrus (↔ § Walrus storage), seal (↔ § Seal
+│     secrets), kiosk (↔ § Transfer policies), suins, deepbook-v3, zksend
 ├── Transactions builder              📖 docs: .ts-sdk-docs/sui/transactions/
 │   ⊃ Serial/ParallelTransactionExecutor — queue/parallelize same-sender txns,
 │     cache gas coins + object versions  📖 docs: .ts-sdk-docs/sui/executors.mdx

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -627,21 +627,37 @@ WALRUS                                📖 docs: .walrus-docs/system-overview/co
 
 ## Seal secrets
 
-Seal is a threshold-encryption / decentralized key-management protocol on Sui.
-Use Seal when application data must be *encrypted at rest* and decryption authority
-is policy-gated (committee threshold, time-lock, access-control).
+Seal is decentralized secrets management (DSM) on Sui: identity-based encryption (IBE)
+where the Move package at `PkgId` owns the `[PkgId]*` identity namespace and its code
+decides who gets decryption keys. NOT a KMS, and not for wallet keys or regulated data
+(📖 docs: .seal-docs/index.mdx § Non-goals).
 
 ```
-SEAL                                  📖 docs: .seal-docs/Design.mdx
-├── Key servers (committees)
-├── Aggregation protocol              → threshold-decryption
-├── Access-policy patterns
+SEAL                                  📖 docs: .seal-docs/index.mdx → .seal-docs/Design.mdx (architecture)
+│
+├── seal_approve* policy functions    📖 docs: .seal-docs/UsingSeal.mdx (§ Access control)
+│   → non-public `entry`; first param = identity bytes SANS PkgId prefix; abort to deny;
+│     side-effect free; evaluated via full-node dry_run_transaction_block — non-atomic
+│     across key servers, so never gate on fast-changing state (§ Limitations)
+│   ↔ Modules & visibility § entry; version shared objects for upgrade safety
+├── Access-policy patterns            📖 docs: .seal-docs/ExamplePatterns.mdx
+│   ⊃ private data, allowlist, subscription, time-lock (TLE), secure voting
+├── Key servers — t-out-of-n threshold; server set FROZEN at encryption time
+│   📖 docs: .seal-docs/Design.mdx (§ Decentralization and trust model)
+│   ├── independent (Open/Permissioned) 📖 docs: .seal-docs/KeyServerOps.mdx
+│   └── decentralized committee mode (MPC, Testnet-only) 📖 docs: .seal-docs/KeyServerCommitteeOps.mdx
+│       ⊃ Aggregator Server — trustless gateway, committee mode only 📖 docs: .seal-docs/Aggregator.mdx
+├── SessionKey — wallet-signed message grants per-package, time-limited key access
+│   📖 docs: .seal-docs/Design.mdx (§ User confirmation and sessions)
+│   ↔ TS SDK: `@mysten/seal` SealClient encrypt/decrypt/fetchKeys 📖 docs: .ts-sdk-docs/seal/
+├── KEM/DEM — Boneh-Franklin IBE on BLS12-381; DEM chosen AT ENCRYPTION TIME (irreversible):
+│   AES-256-GCM default, HMAC-CTR only for onchain decryption (seal::bf_hmac_encryption)
+│   📖 docs: .seal-docs/Design.mdx (§ Cryptographic primitives)
 └── Security best practices           📖 docs: .seal-docs/SecurityBestPractices.mdx
-   ↔ Sui § Authorization patterns (policy gates often use Capability or Witness)
+   ↔ Walrus § blobs — encrypt BEFORE upload; envelope encryption for large/immutable blobs
+     (Seal wraps the symmetric key; rotate policies without re-encrypting the blob)
    ↔ Cryptography & primitives § Threshold/aggregation
 ```
-
-Stub — flesh in v2 follow-up.
 
 ---
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -589,21 +589,39 @@ SUI PROVER                            📖 docs: .sui-prover-docs/guide/SKILL.md
 
 ## Walrus storage
 
-Walrus is a decentralized blob-storage protocol anchored on Sui. The on-chain object
-holds a commitment + availability proof; the blob bytes live in the Walrus storage
-network. Use Walrus when you need verifiable availability without paying Sui storage
-fees per byte.
+Walrus is a decentralized blob-storage protocol coordinated on Sui: blob bytes are
+erasure-coded (RedStuff) across storage nodes; registration, payment, and availability
+proofs live on Sui as objects and events.
 
 ```
-WALRUS                                📖 docs: .walrus-docs/system-overview/
-├── Blob model + Quilt                → small-blob bundling
-├── Walrus Sites                      → static-site hosting on Walrus
-├── HTTP API & TS SDK                 → publish/read paths
-└── Operator / publisher / aggregator → infrastructure roles
-   ↔ Sui § Sui object model (Walrus blob registration creates Sui objects)
+WALRUS                                📖 docs: .walrus-docs/system-overview/core-concepts.mdx
+│
+├── Blob lifecycle — encode → register (BlobRegistered) → upload slivers → certify
+│   → BlobCertified event = Proof of Availability (PoA); blob ID is content-derived
+│   ⊃ `Blob` / `Storage` structs are `key, store` Sui Move objects (↔ Sui § Sui object model)
+│   │  Move usage example  📖 docs: .walrus-docs/examples/move.mdx
+│   ⊃ deletable vs permanent — `deletable: bool` fixed at registration
+│
+├── Quilt — batch ≤666 small blobs into one blob to amortize per-blob overhead
+│   📖 docs: .walrus-docs/system-overview/quilt.mdx
+│   ⚠ QuiltPatchId depends on whole-quilt composition (NOT content-derived);
+│     no per-item delete/extend/share — whole-quilt only
+│
+├── Roles: storage nodes / aggregators (+ caches) / publishers / upload relay
+│   → relay: one POST vs ≈2200 direct-SDK requests per write  📖 docs: .walrus-docs/system-overview/relay.mdx
+│   → node/publisher/aggregator ops  📖 docs: .walrus-docs/operator-guide/
+│
+├── walrus CLI (+ JSON mode)          📖 docs: .walrus-docs/walrus-client/
+├── HTTP API (publisher/aggregator)   📖 docs: .walrus-docs/http-api/
+├── TS SDK — `@mysten/walrus` via client.$extend(walrus()); WalrusFile API
+│   📖 docs: .ts-sdk-docs/walrus/index.mdx   ↔ TS SDK § Core API / client extensions
+├── Walrus Sites — static-site hosting  📖 docs: .walrus-docs/sites/
+│
+└── ⚠ ALL Walrus blobs are PUBLIC; blob IDs are NOT secrets — encrypt before upload
+    📖 docs: .walrus-docs/data-security.mdx
+    ↔ Seal § (encrypt-before-upload; end-to-end tutorial
+      📖 docs: .walrus-docs/seal-encryption-tutorial.mdx)
 ```
-
-Stub — flesh in v2 follow-up. For operations questions consult the operator-guide subtree.
 
 ---
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -556,6 +556,37 @@ ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
 
 ---
 
+## Formal verification (Sui Prover)
+
+The Sui Prover proves `#[spec(prove)]` specifications against Move code (Boogie/Z3).
+A spec is a Move function with the target's signature: `requires` (preconditions),
+`asserts` (abort conditions — must be exhaustive, and placed *before* the call),
+call the target, `ensures` (postconditions); `clone!(ref)` snapshots `&mut` pre-state.
+Specs named `<fn>_spec` compose: used as opaque summaries when proving callers.
+
+```
+SUI PROVER                            📖 docs: .sui-prover-docs/guide/SKILL.md
+│
+├── Spec packages                     → specs live in a sibling `<pkg>_specs` package; `target = pkg::mod::fn` binds cross-module
+│   ⤳ skill: specify (authors specs)  ⤳ skill: verify (re-proves against current code)
+├── Math types (spec-only)            📖 docs: .sui-prover-docs/guide/spec-reference.md
+│   ⊃ `Integer`/`Real` (unbounded — `.to_int()`/`.to_real()`), `Q32`/`Q64`/`Q128` fixed-point
+│   ↔ Onchain finance § Fixed-point math — prove mul_div/share-price invariants without width limits
+├── Ghost variables (prover::ghost)   📖 docs: .sui-prover-docs/sources/ghost.move
+│   → spec-only globals (`declare_global`/`global`) — verify event emission, propagate state between specs
+│   ↔ Sui object model § Transfer functions — any spec touching `public_transfer` MUST declare SpecTransferAddress/-Exists ghosts
+├── Loop & datatype invariants        → `invariant!(|| {...})` inline before loop, or external `#[spec_only(loop_inv(target = ...))]`;
+│   `#[spec_only(inv_target = Struct)]` checks a datatype invariant on construction/mutation
+├── Quantifiers & vector iterators    📖 docs: .sui-prover-docs/sources/vector.move
+│   → `forall!`/`exists!` — lambda must call a named `#[ext(pure)]` predicate; `all!`/`any!`/`count!`/`sum`
+│   ⚠ timeout-prone: keep loop-bearing specs with `requires(forall!(...))` opaque
+└── ⊃ examples                        📖 docs: .sui-prover-docs/examples/ (amm pool spec, showcase container specs, integer-mate real bug)
+```
+
+⤳ skill: specify (authoring workflow) · ⤳ skill: verify (drift detection + re-verification)
+
+---
+
 ## Walrus storage
 
 Walrus is a decentralized blob-storage protocol anchored on Sui. The on-chain object

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -103,7 +103,6 @@ If `move-analyzer` is not available, continue without MCP tools and note that la
 - `⚠` — safety warning / common foot-gun
 - `⤳ skill:` — pointer to a bundled skill that provides actionable guidance
 - `📖 docs:` — entry point in the bundled corpora (search root: `${CLAUDE_PLUGIN_ROOT}/.<source>-docs/`)
-- `⚠ warning` — a foot-gun or anti-pattern to avoid
 
 Follow edges across sections when they point there — this map orients; the corpora are authoritative.
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -378,22 +378,49 @@ AUTHORIZATION                         📖 docs: .sui-docs/develop/security/best
 
 ## Transactions & lifecycle
 
-Sui transactions are *programmable transaction blocks* (PTBs) — composable command
-chains that can move objects, call entry functions, and split/merge in one signed
-batch. Understanding PTB structure, gas model, and authentication paths is required
-before reviewing any transaction-building code (Move side or TS SDK side).
+Sui transactions are *programmable transaction blocks* (PTBs) — ordered command
+chains that can move objects, call Move functions (public or entry), and manage
+coins in one signed, atomic batch. Understanding PTB structure, the consensus
+lifecycle, gas, and authentication paths is required before reviewing any
+transaction-building code (Move side or TS SDK side).
 
 ```
-TRANSACTIONS                          📖 docs: .sui-docs/develop/transactions/index.mdx
-├── PTB structure                     📖 docs: .sui-docs/develop/transactions/ptbs/
-├── Transaction lifecycle             📖 docs: .sui-docs/develop/transactions/transaction-lifecycle.mdx
-├── Transaction auth                  📖 docs: .sui-docs/develop/transactions/transaction-auth/
+TRANSACTIONS                          📖 docs: .sui-docs/develop/transactions/txn-overview.mdx
+│  → two kinds: PTBs (user-submitted) + system transactions (validator-only, sender 0x0)
+│
+├── PTB structure                     📖 docs: .sui-docs/develop/transactions/ptbs/prog-txn-blocks.mdx
+│   ├── Commands: splitCoins / mergeCoins / transferObjects / moveCall / makeMoveVec / publish / upgrade
+│   ├── Arguments: Input(i) / GasCoin / Result(i) / NestedResult(i,j)
+│   │   → GasCoin restrictions: no `&`/`&mut` use; by value only via TransferObjects (SplitCoins first for an owned Coin<SUI>)
+│   ├── ≤ 1,024 commands per PTB; atomic (one failure reverts all); no loops
+│   ├── moveCall targets any `public` fn or any `entry` fn (incl. private / `public(package)` entry)
+│   │   ↔ Authorization § Hot potato — non-public `entry` args must not be in a "hot" clique
+│   └── ⊃ siblings: inputs-and-results.mdx, building-ptb.mdx
+│
+├── Lifecycle                         📖 docs: .sui-docs/develop/transactions/transaction-lifecycle.mdx
+│   → sign → full-node *Transaction Driver* submits to a validator → Mysticeti consensus sequencing
+│     → parallel execution (non-conflicting inputs) → effects → settlement finality (~400–700 ms) → checkpoints
+│
+├── Transaction auth                  📖 docs: .sui-docs/develop/transactions/transaction-auth/auth-overview.mdx
+│   ⊃ siblings: intent-signing, multisig, offline-signing, address-aliases (.mdx)
+│   ↔ Cryptography & primitives § Signing & verification
+│
+├── Soft bundles (SIP-19)             📖 docs: .sui-docs/develop/transactions/soft-bundles.mdx
+│   ⇢ alternative to: single PTB — multi-signer, per-tx revert; best-effort ordering, NOT atomic
+│
 ├── Gas model                         📖 docs: .sui-docs/develop/transaction-payment/gas-in-sui.mdx
-├── Sponsored / gasless txns          📖 docs: .sui-docs/develop/transaction-payment/sponsor-txn.mdx
+│   ├── Sponsored txns                📖 docs: .sui-docs/develop/transaction-payment/sponsor-txn.mdx
+│   │   → sponsor / gas station supplies the gas payment object on the user's behalf
+│   ├── Gasless stablecoin transfers  📖 docs: .sui-docs/develop/transaction-payment/gasless-stablecoin-transfers.mdx
+│   │   → protocol allowlist, sender holds no SUI; deprioritized under congestion — distinct mechanism from sponsorship
+│   └── Local fee markets             📖 docs: .sui-docs/develop/transaction-payment/local-fee-markets.mdx
+│       → per-shared-object rate limit (ExecutionCancelledDueToSharedObjectCongestion); gas price is the only priority lever
+│       ↔ Sui object model § Shared (avoid a single hot shared object; split state per pair/user)
+│
 └── ⤳ skill: move-code-review
 ```
 
-Stub — fleshed in v2 follow-up. Cross-reference `Sui object model § Object ownership`
+Cross-reference `Sui object model § Object ownership`
 for fast-path vs. consensus, and `Authorization patterns` for entry-function guards.
 
 ---

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -81,15 +81,7 @@ If `move-analyzer` is not available, continue without MCP tools and note that la
 
 # Ecosystem Knowledge Graph
 
-> Always-loaded relational map of the Sui ecosystem: Move language constructs,
-> Sui runtime primitives, the off-chain stack (Walrus, Seal, TS SDK) and how they
-> interact, plus pointers to the bundled skills that go deeper. Treat as the
-> conceptual orientation for any task that spans more than one layer; follow the
-> `📖 docs:` pointers via `Glob`/`Grep` to read the actual source content
-> from the bundled corpora.
-
-
-> Master reference for the Sui ecosystem. Maps every concept-stable building block —
+> Always-loaded master reference for the Sui ecosystem. Maps every concept-stable building block —
 > Move language constructs, Sui runtime primitives, the off-chain stack (Walrus, Seal,
 > TS SDK) — how they relate, when each is the right tool, and which bundled skills
 > provide deeper guidance.
@@ -108,21 +100,19 @@ If `move-analyzer` is not available, continue without MCP tools and note that la
 - `↔ integrates with` — bidirectional collaboration; both sides know about each other
 - `⇢ alternative to` — substitutable for the same job (pick one, not both)
 - `⊃ contains` — parent/child or whole/part relationship
+- `⚠` — safety warning / common foot-gun
 - `⤳ skill:` — pointer to a bundled skill that provides actionable guidance
 - `📖 docs:` — entry point in the bundled corpora (search root: `${CLAUDE_PLUGIN_ROOT}/.<source>-docs/`)
 - `⚠ warning` — a foot-gun or anti-pattern to avoid
 
-Cross-reference sections by `Glob`/`Grep` when an edge suggests you should — this map orients,
-the corpora are authoritative.
+Follow edges across sections when they point there — this map orients; the corpora are authoritative.
 
 ---
 
 ## Move type system & abilities
 
-Move's type system is value-oriented and ability-gated. Every type carries an explicit
-set of *abilities* that determines what can be done with values of that type — copied,
-dropped (silently destroyed), stored under an account/object, or used as a top-level
-on-chain object. Mismatched abilities are a compile-time error, not a runtime check.
+Every Move type carries explicit *abilities* (copy/drop/key/store) gating what its
+values can do; ability mismatches are compile-time errors, not runtime checks.
 
 ```
 ABILITIES                             📖 docs: .move-book-docs/book/move-basics/abilities-introduction.md
@@ -228,7 +218,7 @@ MODULES                               📖 docs: .move-book-docs/book/move-basic
 │   📖 docs: .move-book-docs/book/move-basics/visibility.md
 │   📖 docs: .move-book-docs/reference/functions.md (authoritative visibility semantics)
 ├── entry fun ...                     → PTB-callable but NOT callable from other packages
-│   (front-run-sensitive flows, e.g. randomness consumers — see § Cryptography)
+│   (front-run-sensitive flows: randomness consumers § Cryptography, seal_approve* § Seal)
 │   📖 docs: .sui-docs/develop/write-move/sui-move-concepts.mdx
 ├── struct pack/unpack privilege      → construction, destruction, and field access stay
 │   internal to the defining module — the invariant behind witness & hot potato
@@ -260,11 +250,9 @@ PACKAGE LIFECYCLE
 
 ## Sui object model
 
-Sui's runtime is object-centric, not account-centric. Every long-lived value lives
-inside an *object* with a globally-unique `UID`, an *ownership* mode, and a *version*.
-The right ownership mode is the single most consequential design choice in any Sui
-package — it determines parallelizability, who can mutate the object, and whether
-consensus is required.
+Sui's runtime is object-centric: every long-lived value lives in an *object* with a `UID`,
+an *ownership* mode, and a *version*. Ownership choice determines parallelizability,
+who can mutate, and whether consensus is required.
 
 ```
 SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index.mdx
@@ -282,6 +270,7 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 │   │
 │   ├── Shared                        → consensus-required; multi-writer; congestion-prone
 │   │   ⤳ skill: move-code-review (look for shared-object hot spots)
+│   │   ↔ Transactions § Local fee markets (per-object congestion pricing)
 │   │   ⇢ alternative: Party objects  → single-owner, consensus-sequenced (see below)
 │   │   ⇢ alternative: derived objects (parent-child) when ownership is hierarchical
 │   │
@@ -338,6 +327,7 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
     │   the defining module (mirrors public_share_object / public_freeze_object)
     ├── transfer::party_transfer(obj, party)  → party-owned (single_owner)
     ├── transfer::receive(&mut parent.id, Receiving<T>) → transfer-to-object (TTO)
+    ├── ↔ Formal verification § Ghost variables (public_transfer specs need ghosts)
     └── ⤳ skill: move-code-review (blind transfers are a common SEC-AC bug class)
 ```
 
@@ -358,15 +348,13 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 
 ## Authorization patterns
 
-Move's compile-time guarantees enable authorization patterns that don't require
-runtime checks. The toolkit below is what idiomatic Sui packages use to express
-"who is allowed to do what" without storing access-control lists. Pick the lightest
-pattern that expresses your intent.
+Compile-time patterns expressing "who may do what" without access-control lists —
+pick the lightest pattern that expresses your intent.
 
 ```
 AUTHORIZATION                         📖 docs: .sui-docs/develop/security/best-practices.mdx (§ Access control)
-│   (the Move Book authorization-patterns.md index is currently empty — route to the
-│    per-pattern chapters below)
+│   (authorization-patterns.md index is empty upstream — route to per-pattern chapters)
+│   → Modules & visibility § struct pack/unpack privilege (the compile-time bedrock)
 │
 ├── Capability                        📖 docs: .move-book-docs/book/programmability/capability.md
 │   → owning a `XxxCap` object proves the right to perform privileged ops
@@ -392,7 +380,9 @@ AUTHORIZATION                         📖 docs: .sui-docs/develop/security/best
 ├── Hot potato pattern                📖 docs: .move-book-docs/book/programmability/hot-potato-pattern.md
 │   → struct with NO abilities at all (a no-drop-but-store struct could be stashed); caller MUST consume via specific function
 │   ↔ flash loans, transient receipts, in-progress trade objects
-│   ↔ framework hot potatoes: transfer_policy::TransferRequest, token::ActionRequest
+│   ↔ framework hot potatoes: transfer_policy::TransferRequest, token::ActionRequest,
+│     PAS Request, deepbook FlashLoan (§ Transfer policies, § Onchain finance)
+│   ↔ Transactions § PTB structure — hot values can't flow into non-public `entry` calls
 │   ⤳ skill: move-code-review (every hot-potato needs an exhaustive consume function)
 │   ⇢ alternative: Option-wrapped builder when the consume step is optional
 │
@@ -418,36 +408,28 @@ AUTHORIZATION                         📖 docs: .sui-docs/develop/security/best
 
 ## Transactions & lifecycle
 
-Sui transactions are *programmable transaction blocks* (PTBs) — ordered command
-chains that can move objects, call Move functions (public or entry), and manage
-coins in one signed, atomic batch. Understanding PTB structure, the consensus
-lifecycle, gas, and authentication paths is required before reviewing any
-transaction-building code (Move side or TS SDK side).
+Sui transactions are *programmable transaction blocks* (PTBs) — ordered command chains
+that move objects, call Move functions (public or entry), and manage coins in one
+signed, atomic batch.
 
 ```
 TRANSACTIONS                          📖 docs: .sui-docs/develop/transactions/txn-overview.mdx
 │  → two kinds: PTBs (user-submitted) + system transactions (validator-only, sender 0x0)
-│
 ├── PTB structure                     📖 docs: .sui-docs/develop/transactions/ptbs/prog-txn-blocks.mdx
 │   ├── Commands: splitCoins / mergeCoins / transferObjects / moveCall / makeMoveVec / publish / upgrade
 │   ├── Arguments: Input(i) / GasCoin / Result(i) / NestedResult(i,j)
-│   │   → GasCoin restrictions: no `&`/`&mut` use; by value only via TransferObjects (SplitCoins first for an owned Coin<SUI>)
 │   ├── ≤ 1,024 commands per PTB; atomic (one failure reverts all); no loops
 │   ├── moveCall targets any `public` fn or any `entry` fn (incl. private / `public(package)` entry)
 │   │   ↔ Authorization § Hot potato — non-public `entry` args must not be in a "hot" clique
 │   └── ⊃ siblings: inputs-and-results.mdx, building-ptb.mdx
-│
 ├── Lifecycle                         📖 docs: .sui-docs/develop/transactions/transaction-lifecycle.mdx
 │   → sign → full-node *Transaction Driver* submits to a validator → Mysticeti consensus sequencing
 │     → parallel execution (non-conflicting inputs) → effects → settlement finality (~400–700 ms) → checkpoints
-│
 ├── Transaction auth                  📖 docs: .sui-docs/develop/transactions/transaction-auth/auth-overview.mdx
 │   ⊃ siblings: intent-signing, multisig, offline-signing, address-aliases (.mdx)
 │   ↔ Cryptography & primitives § Signing & verification
-│
 ├── Soft bundles (SIP-19)             📖 docs: .sui-docs/develop/transactions/soft-bundles.mdx
 │   ⇢ alternative to: single PTB — multi-signer, per-tx revert; best-effort ordering, NOT atomic
-│
 ├── Gas model                         📖 docs: .sui-docs/develop/transaction-payment/gas-in-sui.mdx
 │   ├── Sponsored txns                📖 docs: .sui-docs/develop/transaction-payment/sponsor-txn.mdx
 │   │   → sponsor / gas station supplies the gas payment object on the user's behalf
@@ -456,21 +438,16 @@ TRANSACTIONS                          📖 docs: .sui-docs/develop/transactions/
 │   └── Local fee markets             📖 docs: .sui-docs/develop/transaction-payment/local-fee-markets.mdx
 │       → per-shared-object rate limit (ExecutionCancelledDueToSharedObjectCongestion); gas price is the only priority lever
 │       ↔ Sui object model § Shared (avoid a single hot shared object; split state per pair/user)
-│
 └── ⤳ skill: move-code-review
 ```
-
-Cross-reference `Sui object model § Object ownership`
-for fast-path vs. consensus, and `Authorization patterns` for entry-function guards.
 
 ---
 
 ## Transfer policies & kiosk
 
-`TransferPolicy<T>` is the type-owner-controlled primitive gating how `T` changes hands;
-Kiosk is the framework marketplace built on it. Every kiosk purchase issues a
-`TransferRequest` hot potato that only the matching shared `TransferPolicy<T>` can confirm —
-unconfirmed request = failed transaction.
+`TransferPolicy<T>` gates how `T` changes hands; Kiosk is the framework marketplace on top.
+Every kiosk purchase issues a `TransferRequest` hot potato only the matching shared
+`TransferPolicy<T>` can confirm — unconfirmed request = failed transaction.
 
 ```
 TRANSFER POLICIES                     📖 docs: .sui-docs/develop/objects/transfers/transfer-policies.mdx
@@ -497,9 +474,8 @@ TRANSFER POLICIES                     📖 docs: .sui-docs/develop/objects/trans
 
 ## Cryptography & primitives
 
-Sui exposes battle-tested primitives directly from the `sui::*` framework rather than
-forcing every package to vendor its own crypto. Use the framework primitives unless
-you have a specific, audited reason to roll your own.
+Use the framework's `sui::*` primitives unless you have a specific, audited reason
+to roll your own crypto.
 
 ```
 CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
@@ -514,7 +490,7 @@ CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
 │   ├── ed25519, secp256k1, secp256r1  → on-chain verify primitives
 │   ├── BLS12-381                      → aggregatable signatures, threshold schemes
 │   └── Multisig & passkey auth        → tx-level, not Move-call-level
-│       ↔ § Transactions § Transaction auth
+│       ↔ § Transactions § Transaction auth  ↔ TS SDK § Signing (external Signers)
 │
 ├── ZK primitives
 │   ├── Groth16 verifier               📖 docs: .sui-docs/develop/cryptography/groth16.mdx
@@ -540,44 +516,34 @@ CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
     ↔ Seal § threshold encryption (off-chain peer to this on-chain primitive set)
 ```
 
-**Cross-references**
-
-- For *secrets/encryption at rest*, use **Seal** (off-chain, threshold key management) — not Move-side crypto.
-  ⤳ Seal section below
-- For *blob storage with availability commitments*, use **Walrus** — Sui anchors the commitment, Walrus stores the bytes.
-  ⤳ Walrus section below
-- For *commit-reveal randomness in DeFi protocols*, layer ECVRF + on-chain Random.
-  ⤳ skill: oz-math (numerics often needed alongside)
+**Cross-references** — secrets/encryption at rest → **Seal** (threshold decryption, not a
+KMS; § Seal secrets); blob storage with availability proofs → **Walrus** (§ Walrus storage);
+commit-reveal randomness → ECVRF + on-chain Random (⤳ skill: oz-math for the numerics).
 
 ---
 
 ## Onchain finance & math
 
-DeFi-shaped Move packages share a common toolkit: `Coin<T>` / `Balance<T>` for open-loop
-fungible value, closed-loop tokens and PAS for permissioned assets, DeepBookV3 for
-orderbook liquidity, and fixed-point math for price/share calculations.
+The DeFi toolkit: open-loop `Coin<T>`/`Balance<T>`, closed-loop tokens and PAS for
+permissioned assets, DeepBookV3 orderbook, and fixed-point math.
 
 ```
 ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
-│
 ├── Coin<T>, Balance<T>, TreasuryCap<T> → standard open-loop currency (`key + store`: wrappable, freely transferable)
 │   📖 docs: .sui-docs/onchain-finance/fungible-tokens/index.mdx
 │   ⊃ Coin standards: legacy `coin::create_currency` ⇢ newer Currency Standard via `sui::coin_registry`
 │     (new_currency / new_currency_with_otw, MetadataCap, supply states)
 │     📖 docs: .sui-docs/onchain-finance/fungible-tokens/currency.mdx
-│
 ├── Closed-loop tokens                📖 docs: .sui-docs/onchain-finance/closed-loop-token/index.mdx
 │   → `Token<T>` is `key`-only (no store): can't be wrapped, DOF-stored, or freely transferred
 │   ⊃ TokenPolicy + Rules → per-action programmable restrictions
 │     📖 docs: .sui-docs/onchain-finance/closed-loop-token/token-policy.mdx
 │   ⊃ ActionRequest → hot potato issued by protected actions (transfer/spend/to_coin/from_coin)
 │     ↔ § Authorization patterns § Hot potato   📖 docs: .sui-docs/onchain-finance/closed-loop-token/action-request.mdx
-│
 ├── PAS (Permissioned Asset Standard) 📖 docs: .sui-docs/onchain-finance/pas/pas-architecture.mdx
 │   → per-address derived shared Accounts proxy ownership; every movement is a hot-potato
 │     Request that must collect approval-witness stamps per issuer Policies (TS pkg: @mysten/pas)
 │   ⇢ alternative to: Closed-loop tokens — for regulated assets needing issuer oversight
-│
 ├── DeepBookV3                        📖 docs: .sui-docs/onchain-finance/deepbookv3/design.mdx
 │   → onchain CLOB; shared `Pool` (Book/State/Vault) + `PoolRegistry` + reusable `BalanceManager`
 │   ⊃ Pool types: volatile / stable / whitelisted (0-fee); fees payable in DEEP (20% cheaper than input token)
@@ -585,18 +551,15 @@ ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
 │     📖 docs: .sui-docs/onchain-finance/deepbookv3/contract-information/flash-loans.mdx
 │   ⊃ Margin — leveraged positions, onchain liquidation  📖 docs: .sui-docs/onchain-finance/deepbook-margin/deepbook-margin.mdx
 │   ⊃ Predict — prediction markets, oracle-driven pricing  📖 docs: .sui-docs/onchain-finance/deepbook-predict/deepbook-predict.mdx
-│
 ├── Payments                          📖 docs: .sui-docs/onchain-finance/payment-kit.mdx
 │   ⊃ Payment Kit — receipts, registries, duplicate prevention, payment URIs
 │     ↔ TS SDK § payment-kit (📖 docs: .ts-sdk-docs/payment-kit/index.mdx)
 │   ⊃ Payment intents — heterogeneous payment ops batched in one atomic PTB
 │     → § Transactions § PTB structure   📖 docs: .sui-docs/onchain-finance/payment-intents.mdx
-│
 ├── Fixed-point math                  → std::fixed_point32; per-type integer modules
 │   std::u8–u256 (max, diff, divide_and_round_up, sqrt, pow)
 │   📖 docs: .move-book-docs/book/move-basics/standard-library.md
 │   ↔ § Formal verification (Sui Prover) — spec-only Integer/Real types for overflow-free specs
-│
 └── ⤳ skill: oz-math (math safety audit)
    ⤳ skill: move-code-review (overflow, rounding bias, MEV exposure)
 ```
@@ -605,15 +568,12 @@ ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
 
 ## Formal verification (Sui Prover)
 
-The Sui Prover proves `#[spec(prove)]` specifications against Move code (Boogie/Z3).
-A spec is a Move function with the target's signature: `requires` (preconditions),
-`asserts` (abort conditions — must be exhaustive, and placed *before* the call),
-call the target, `ensures` (postconditions); `clone!(ref)` snapshots `&mut` pre-state.
-Specs named `<fn>_spec` compose: used as opaque summaries when proving callers.
+The Sui Prover proves `#[spec(prove)]` specs against Move code (Boogie/Z3). A spec mirrors
+the target's signature: `requires` → exhaustive `asserts` (before the call) → call → `ensures`;
+`clone!(ref)` snapshots `&mut` pre-state. `<fn>_spec` specs compose as opaque summaries.
 
 ```
 SUI PROVER                            📖 docs: .sui-prover-docs/guide/SKILL.md
-│
 ├── Spec packages                     → specs live in a sibling `<pkg>_specs` package; `target = pkg::mod::fn` binds cross-module
 │   ⤳ skill: specify (authors specs)  ⤳ skill: verify (re-proves against current code)
 ├── Math types (spec-only)            📖 docs: .sui-prover-docs/guide/spec-reference.md
@@ -627,43 +587,36 @@ SUI PROVER                            📖 docs: .sui-prover-docs/guide/SKILL.md
 ├── Quantifiers & vector iterators    📖 docs: .sui-prover-docs/sources/vector.move
 │   → `forall!`/`exists!` — lambda must call a named `#[ext(pure)]` predicate; `all!`/`any!`/`count!`/`sum`
 │   ⚠ timeout-prone: keep loop-bearing specs with `requires(forall!(...))` opaque
-└── ⊃ examples                        📖 docs: .sui-prover-docs/examples/ (amm pool spec, showcase container specs, integer-mate real bug)
+├── ⊃ examples                        📖 docs: .sui-prover-docs/examples/ (amm pool spec, showcase container specs, integer-mate real bug)
+└── ↔ Tooling § sui-prover (MCP) — prove_package / list_specs run the proofs
 ```
-
-⤳ skill: specify (authoring workflow) · ⤳ skill: verify (drift detection + re-verification)
 
 ---
 
 ## Walrus storage
 
-Walrus is a decentralized blob-storage protocol coordinated on Sui: blob bytes are
-erasure-coded (RedStuff) across storage nodes; registration, payment, and availability
-proofs live on Sui as objects and events.
+Decentralized blob storage coordinated on Sui: blob bytes are erasure-coded (RedStuff)
+across storage nodes; registration, payment, and availability proofs live on Sui.
 
 ```
 WALRUS                                📖 docs: .walrus-docs/system-overview/core-concepts.mdx
-│
 ├── Blob lifecycle — encode → register (BlobRegistered) → upload slivers → certify
 │   → BlobCertified event = Proof of Availability (PoA); blob ID is content-derived
 │   ⊃ `Blob` / `Storage` structs are `key, store` Sui Move objects (↔ Sui § Sui object model)
 │   │  Move usage example  📖 docs: .walrus-docs/examples/move.mdx
 │   ⊃ deletable vs permanent — `deletable: bool` fixed at registration
-│
 ├── Quilt — batch ≤666 small blobs into one blob to amortize per-blob overhead
 │   📖 docs: .walrus-docs/system-overview/quilt.mdx
 │   ⚠ QuiltPatchId depends on whole-quilt composition (NOT content-derived);
 │     no per-item delete/extend/share — whole-quilt only
-│
 ├── Roles: storage nodes / aggregators (+ caches) / publishers / upload relay
 │   → relay: one POST vs ≈2200 direct-SDK requests per write  📖 docs: .walrus-docs/system-overview/relay.mdx
 │   → node/publisher/aggregator ops  📖 docs: .walrus-docs/operator-guide/
-│
 ├── walrus CLI (+ JSON mode)          📖 docs: .walrus-docs/walrus-client/
 ├── HTTP API (publisher/aggregator)   📖 docs: .walrus-docs/http-api/
 ├── TS SDK — `@mysten/walrus` via client.$extend(walrus()); WalrusFile API
 │   📖 docs: .ts-sdk-docs/walrus/index.mdx   ↔ TS SDK § Core API / client extensions
 ├── Walrus Sites — static-site hosting  📖 docs: .walrus-docs/sites/
-│
 └── ⚠ ALL Walrus blobs are PUBLIC; blob IDs are NOT secrets — encrypt before upload
     📖 docs: .walrus-docs/data-security.mdx
     ↔ Seal § (encrypt-before-upload; end-to-end tutorial
@@ -674,14 +627,12 @@ WALRUS                                📖 docs: .walrus-docs/system-overview/co
 
 ## Seal secrets
 
-Seal is decentralized secrets management (DSM) on Sui: identity-based encryption (IBE)
-where the Move package at `PkgId` owns the `[PkgId]*` identity namespace and its code
-decides who gets decryption keys. NOT a KMS, and not for wallet keys or regulated data
-(📖 docs: .seal-docs/index.mdx § Non-goals).
+Decentralized secrets management on Sui: identity-based encryption (IBE) where the Move
+package at `PkgId` owns the `[PkgId]*` identity namespace and its code decides who gets
+decryption keys. NOT a KMS (📖 docs: .seal-docs/index.mdx § Non-goals).
 
 ```
 SEAL                                  📖 docs: .seal-docs/index.mdx → .seal-docs/Design.mdx (architecture)
-│
 ├── seal_approve* policy functions    📖 docs: .seal-docs/UsingSeal.mdx (§ Access control)
 │   → non-public `entry`; first param = identity bytes SANS PkgId prefix; abort to deny;
 │     side-effect free; evaluated via full-node dry_run_transaction_block — non-atomic
@@ -710,46 +661,38 @@ SEAL                                  📖 docs: .seal-docs/index.mdx → .seal-
 
 ## TypeScript SDK & 2.0 migration
 
-Any TypeScript code importing `@mysten/*` may still be on the 1.x API; SDK 2.0
-(current major) has extensive breaking changes pre-cutoff training does not know:
-packages are ESM-only, every client constructor requires an explicit `network`
-param, 1.x `SuiClient` is REMOVED, and `core.getObject` THROWS on missing objects
-(v1 returned `null`).
+Assume `@mysten/*` code may still be on 1.x; SDK 2.0 (current major) breaking changes:
+ESM-only packages, explicit `network` param in every client constructor, 1.x `SuiClient`
+REMOVED, `core.getObject` THROWS on missing objects (v1 returned `null`).
 
 ```
 TS SDK                                📖 docs: .ts-sdk-docs/sui/migrations/sui-2.0/index.mdx
-│
 ├── Clients (3 transports)            📖 docs: .ts-sdk-docs/sui/clients/index.mdx
 │   ├── SuiGrpcClient (`@mysten/sui/grpc`) — recommended default
 │   ├── SuiGraphQLClient — advanced query patterns full nodes can't serve directly
 │   ├── SuiJsonRpcClient — deprecated, decommission pending; migrate to gRPC
 │   └── 1.x SuiClient — REMOVED in 2.0 (not merely deprecated)
-│
+│   ↔ § Accessing on-chain data (gRPC/GraphQL read paths, event queries)
 ├── Core API — `client.core` / ClientWithCoreApi, transport-agnostic common ops
 │   📖 docs: .ts-sdk-docs/sui/clients/core.mdx
 │   ⊃ `$extend(...)` client extensions — walrus, seal, kiosk, suins, deepbook-v3,
 │     zksend all ship as extensions
-│
 ├── Transactions builder              📖 docs: .ts-sdk-docs/sui/transactions/
 │   ⊃ Serial/ParallelTransactionExecutor — queue/parallelize same-sender txns,
 │     cache gas coins + object versions  📖 docs: .ts-sdk-docs/sui/executors.mdx
-│
 ├── Signing — keypairs + external Signers (AWS/GCP KMS, Ledger, WebCrypto,
 │   passkey, multisig)                📖 docs: .ts-sdk-docs/sui/cryptography/signers/index.mdx
 │   ↔ Cryptography & primitives § Signing & verification
-│
 ├── BCS — `bcs.struct(...)`           📖 docs: .ts-sdk-docs/bcs/index.mdx
 │   ⊃ Sui pre-defined schemas (`@mysten/sui/bcs`)  📖 docs: .ts-sdk-docs/sui/bcs.mdx
 │   ⇢ alternative: `@mysten/codegen` — typed bindings generated from Move packages
 │     (in development, may break)     📖 docs: .ts-sdk-docs/codegen/
-│
 ├── dapp-kit                          📖 docs: .ts-sdk-docs/dapp-kit/index.mdx
 │   ├── @mysten/dapp-kit-core (framework-agnostic) + @mysten/dapp-kit-react (hooks)
 │   └── legacy @mysten/dapp-kit — deprecated, JSON-RPC-only, no gRPC/GraphQL ever
 │       📖 docs: .ts-sdk-docs/sui/migrations/sui-2.0/dapp-kit.mdx (migration guide)
-│
-├── kiosk SDK                         📖 docs: .ts-sdk-docs/kiosk/
-├── payment-kit                       📖 docs: .ts-sdk-docs/payment-kit/
+├── kiosk SDK                         📖 docs: .ts-sdk-docs/kiosk/  ↔ § Transfer policies & kiosk
+├── payment-kit                       📖 docs: .ts-sdk-docs/payment-kit/  ↔ Onchain finance § Payments
 ├── sponsor (experimental incubation) 📖 docs: .ts-sdk-docs/sponsor/
 └── zksend claim links                📖 docs: .ts-sdk-docs/zksend/
 ```

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -184,6 +184,13 @@ REFERENCES                            📖 docs: .move-book-docs/book/move-basic
         ⤳ skill: move-code-review (look for unconsumed hot-potatoes & resource leaks)
 ```
 
+**Enums & match**                     📖 docs: .move-book-docs/book/move-basics/enum-and-match.md
+
+- `enum` variants (≤100, no recursion) unify shapes under one type; internal to the defining
+  module — construct/read/unpack only there (export `is_variant`-style accessors for callers)
+- `match` arms are compiler-checked exhaustive; `_` wildcard as default arm
+  📖 docs: .move-book-docs/reference/control-flow/pattern-matching.md
+
 **Move 2024 idioms** that the agent should *prefer over their pre-2024 equivalents*
 (📖 docs: .move-book-docs/book/guides/code-quality-checklist.md):
 
@@ -196,6 +203,9 @@ REFERENCES                            📖 docs: .move-book-docs/book/move-basic
 - `package::Type::method(...)` qualified calls when the receiver is ambiguous
 
 ⤳ skill: move-code-quality (the canonical checklist for these)
+
+> When `book/` prose is insufficient, `.move-book-docs/reference/` is the authoritative
+> language-semantics tree (abilities, generics, enums, pattern matching, modes).
 
 ---
 
@@ -228,6 +238,22 @@ MODULES                               📖 docs: .move-book-docs/book/move-basic
     code is unpublishable (#[test_only] = sugar for #[mode(test)])
     📖 docs: .move-book-docs/book/move-advanced/modes.md
     ⤳ skill: move-code-quality
+```
+
+**Package lifecycle**
+
+```
+PACKAGE LIFECYCLE
+├── Publish                           📖 docs: .sui-docs/develop/publish-upgrade-packages/deploy.mdx
+├── Upgrade                           📖 docs: .sui-docs/develop/publish-upgrade-packages/upgrade.mdx
+│   → layout-compatible only: public fn signatures + struct layouts/abilities frozen;
+│     `init` does NOT re-run on upgrade; old package versions stay callable on-chain forever
+│   → versioned-shared-object pattern: `VERSION` const + `version: u64` field + AdminCap-gated
+│     migrate fn; guard entry points with assert!(obj.version == VERSION)
+├── Custom upgrade policies           📖 docs: .sui-docs/develop/publish-upgrade-packages/custom-policies.mdx
+│   → UpgradeCap → § Authorization § Capability; package::make_immutable burns upgradeability
+└── Upgradeability practices          📖 docs: .move-book-docs/book/guides/upgradeability-practices.md
+    → public structs/fns can never change signature; public(package)/entry/private CAN
 ```
 
 ---
@@ -275,8 +301,16 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 ├── Dynamic fields                    📖 docs: .sui-docs/develop/objects/dynamic-fields.mdx
 │   ⊃ dynamic_field    — heterogeneous typed children at arbitrary keys
 │   ⊃ dynamic_object_field — children that are themselves Sui objects (preserve UID)
-│   ⇢ alternative to: VecMap, Table — when you need unbounded growth or rare access
+│   ⊃ Table/Bag (+ Object* variants) are built ON dynamic fields — not peers (see Collections)
+│   ⚠ deleting a parent with live dynamic fields orphans them forever (even non-`drop` values)
 │   ⤳ skill: move-code-review (DOF lookups can hide gas costs; audit access patterns)
+│
+├── Collections
+│   ├── in-memory: vector / VecSet / VecMap → struct-embedded, bounded by object size limit
+│   │   📖 docs: .move-book-docs/book/programmability/collections.md
+│   └── dynamic: Bag/Table + ObjectBag/ObjectTable/LinkedTable → DF-backed objects (`key + store`),
+│       unbounded; size-tracked so non-empty destruction aborts (no orphaned fields)
+│       📖 docs: .move-book-docs/book/programmability/dynamic-collections.md
 │
 ├── Derived objects                   📖 docs: .sui-docs/develop/objects/derived-objects.mdx
 │   → UID deterministically derived from (parent UID, key) — key need not be unique-typed
@@ -287,8 +321,14 @@ SUI OBJECT MODEL                      📖 docs: .sui-docs/develop/objects/index
 │
 ├── Versioning                        📖 docs: .sui-docs/develop/objects/versioning.mdx
 │   ↔ Each mutation bumps the object version (used by consensus + replay)
-│   ↔ Package upgrades — `version: u64` field convention for upgradeable structs
+│   ↔ Package upgrades — `version: u64` guard convention → § Modules & visibility § Package
+│     lifecycle  📖 docs: .sui-docs/develop/publish-upgrade-packages/upgrade.mdx
 │   ⤳ skill: move-code-review (version mismatch = silent foot-gun)
+│
+├── Events                            📖 docs: .move-book-docs/book/programmability/events.md
+│   → sui::event::emit<T: copy + drop>(event); verifier requires T internal to the emitting module
+│   → stored in transaction effects, not on-chain state; sender + timestamp come free in metadata
+│   ↔ § Accessing on-chain data (query/index)  ↔ TS SDK (event queries)
 │
 └── Transfer functions                📖 docs: .move-book-docs/book/appendix/transfer-functions.md
     ├── transfer::transfer(obj, addr)        → address-owned
@@ -488,6 +528,13 @@ CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
 │   → divide-logic pattern: commit random result in tx1, consume in tx2 (revert griefing)
 │   ⤳ skill: move-code-review (never use timestamps, tx hash, or coin balances as randomness)
 │   ⇢ alternative: commit-reveal with off-chain entropy when external sources are required
+│
+├── Time                              📖 docs: .sui-docs/sui-stack/on-chain-primitives/access-time.mdx
+│   → sui::clock::Clock — shared singleton at 0x6; accept `&Clock` ONLY (entry fns taking
+│     `&mut Clock`/value fail to publish); timestamp_ms updates per checkpoint (~1/4 s); consensus-only
+│   → tx_context::epoch_timestamp_ms() — epoch-start time, fastpath-compatible, ~24h granularity
+│     📖 docs: .move-book-docs/book/programmability/epoch-and-time.md
+│   ⤳ skill: move-code-review (⚠ timestamps are NOT randomness — see Randomness above)
 │
 └── Threshold/aggregation
     ↔ Seal § threshold encryption (off-chain peer to this on-chain primitive set)
@@ -709,6 +756,58 @@ TS SDK                                📖 docs: .ts-sdk-docs/sui/migrations/sui
 
 ⤳ Always read the 2.0 migration index when editing `@mysten/*` code — it is the
 load-bearing read; per-package guides live beside it.
+
+---
+
+## Accessing on-chain data
+
+Off-chain read paths for txns/objects/events/checkpoints. JSON-RPC is deprecated
+(deactivation planned July 2026) — new code picks gRPC or GraphQL.
+
+```
+ACCESSING DATA                        📖 docs: .sui-docs/develop/accessing-data/data-serving.mdx
+├── gRPC          → fast, type-safe full-node access + tx execution
+│   📖 docs: .sui-docs/develop/accessing-data/grpc/what-is-grpc.mdx
+├── GraphQL RPC   → indexed, filterable reads; pagination + service limits
+│   📖 docs: .sui-docs/develop/accessing-data/graphql/graphql-rpc.mdx
+│   ⊃ JSON-RPC → gRPC/GraphQL method mapping  📖 docs: .sui-docs/develop/accessing-data/json-rpc-migration.mdx
+├── Custom indexers → sui-indexer-alt-framework (Rust): ingest/process/store your own pipeline
+│   📖 docs: .sui-docs/develop/accessing-data/custom-indexer/custom-indexers.mdx
+├── Archival Store  → historical point lookups beyond full-node retention/pruning
+│   📖 docs: .sui-docs/develop/accessing-data/archival-store/what-is-archival-store.mdx
+├── Querying events                   📖 docs: .sui-docs/develop/accessing-data/using-events.mdx
+│   └── Authenticated events → light-client-verifiable event stream (MMR proofs)
+│       📖 docs: .sui-docs/develop/accessing-data/authenticated-events.mdx
+└── ↔ TS SDK § Clients (SuiGrpcClient / SuiGraphQLClient)  ↔ Sui object model § Events
+```
+
+---
+
+## Testing Move packages
+
+Tests are Move functions run by the compiler's built-in framework (`sui move test`);
+same VM semantics as production, but network/storage behavior is simulated.
+
+```
+TESTING                               📖 docs: .move-book-docs/book/testing/index.md
+├── #[test] / #[test, expected_failure] → auto-discovered; unexpected abort = failure
+│   📖 docs: .move-book-docs/book/testing/testing-basics.md
+├── assert! (abort code optional in tests); assert_eq!/assert_ref_eq! from std::unit_test
+│   📖 docs: .move-book-docs/book/testing/test-utilities.md
+├── test_scenario → multi-tx simulation: begin/next_tx/end (one scenario per test);
+│   objects transferred in tx N are only takeable after next_tx
+│   📖 docs: .move-book-docs/book/testing/test-scenario.md
+├── System-object helpers: coin::mint_for_testing / balance::create_for_testing /
+│   clock::create_for_testing (+ burn/destroy `_for_testing` counterparts)
+│   📖 docs: .move-book-docs/book/testing/using-system-objects.md
+├── #[random_test] → property-based random inputs (compiler feature, NOT sui::random)
+│   📖 docs: .move-book-docs/book/testing/random-test.md
+├── Coverage & gas: `sui move test --coverage` (+ `sui move coverage summary`); `-s` stats
+│   (computation units only) + `sui analyze-trace`
+│   📖 docs: .move-book-docs/book/testing/coverage.md, .move-book-docs/book/testing/gas-profiling.md
+└── Sui-side testing & debugging docs 📖 docs: .sui-docs/develop/testing-debugging/
+    ↔ § Formal verification (Sui Prover) — proofs complement, never replace, tests
+```
 
 ---
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -427,20 +427,31 @@ for fast-path vs. consensus, and `Authorization patterns` for entry-function gua
 
 ## Transfer policies & kiosk
 
-Transfer policies define rules a buyer/seller must satisfy before an object can change
-hands. Kiosk is the canonical marketplace primitive built on top.
+`TransferPolicy<T>` is the type-owner-controlled primitive gating how `T` changes hands;
+Kiosk is the framework marketplace built on it. Every kiosk purchase issues a
+`TransferRequest` hot potato that only the matching shared `TransferPolicy<T>` can confirm —
+unconfirmed request = failed transaction.
 
 ```
-TRANSFER POLICIES                     📖 docs: .sui-docs/develop/objects/transfers/
-├── transfer-policies                 → declare rules; policy is `T`-typed
-├── custom-rules                      → omit `store` so only the defining module can
-│                                       transfer the type (module-gated transfer fns)
-├── rule variants (in transfer-policies) → royalty rules, time-based rules, witness/capability rules
-├── Kiosk                             📖 docs: .sui-docs/onchain-finance/kiosk/
-└── ⤳ skill: move-code-review
+TRANSFER POLICIES                     📖 docs: .sui-docs/develop/objects/transfers/transfer-policies.mdx
+├── Rule anatomy: RuleWitness (drop) + Config (store, drop) + cap-gated add + action fn adds TransferReceipt
+│   ├── confirm_request → compares receipts (VecSet<TypeName>) against policy.rules; mismatch aborts
+│   ├── Rule variants → royalty (paid()/item()/from() getters), time-based (Clock), witness/capability-gated
+│   ├── TransferRequest               → § Authorization patterns § Hot potato (no abilities; must be confirmed)
+│   └── TransferPolicyCap<T>          → § Authorization patterns § Capability (rule install/removal is cap-gated)
+├── custom-rules                      📖 docs: .sui-docs/develop/objects/transfers/custom-rules.mdx
+│   → omit `store` so only the defining module can transfer the type (module-gated transfer fns)
+├── transfer-to-object                📖 docs: .sui-docs/develop/objects/transfers/transfer-to-object.mdx
+│   → send to a 32-byte object ID; receive via `Receiving<T>` PTB argument; NOT supported for party objects
+├── Kiosk                             📖 docs: .sui-docs/onchain-finance/kiosk/kiosk-example.mdx
+│   ├── shared object (§ Sui object model § Shared); KioskOwnerCap (§ Capability) → place/take/list/lock/withdraw
+│   ├── trading T requires a shared TransferPolicy<T>; without one, assets can be stored but not sold
+│   ├── Kiosk apps                    📖 docs: .sui-docs/onchain-finance/kiosk/kiosk-apps.mdx
+│   │   → basic: uid_mut_as_owner + dynamic fields (§ Sui object model § Dynamic fields)
+│   │   → permissioned: `kiosk_extension` module — witness-gated install, tamper-proof app storage
+│   └── ↔ TS SDK § kiosk SDK          📖 docs: .ts-sdk-docs/kiosk/index.mdx
+└── ⤳ skill: move-code-review (unconsumed TransferRequest paths; rule bypass via a second wrapped policy)
 ```
-
-Stub — flesh in follow-up when chunk extraction tests this section.
 
 ---
 

--- a/agents/sui-pilot-agent.md
+++ b/agents/sui-pilot-agent.md
@@ -506,26 +506,53 @@ CRYPTOGRAPHY                          📖 docs: .sui-docs/develop/cryptography/
 
 ## Onchain finance & math
 
-DeFi-shaped Move packages share a common toolkit: `Coin<T>` / `Balance<T>` for fungible
-value, closed-loop tokens for permissioned currencies, DeepBookV3 for orderbook
-liquidity, and fixed-point math primitives for price/share calculations.
+DeFi-shaped Move packages share a common toolkit: `Coin<T>` / `Balance<T>` for open-loop
+fungible value, closed-loop tokens and PAS for permissioned assets, DeepBookV3 for
+orderbook liquidity, and fixed-point math for price/share calculations.
 
 ```
 ONCHAIN FINANCE                       📖 docs: .sui-docs/onchain-finance/
-├── Coin<T>, Balance<T>, TreasuryCap<T>  → standard fungible currency
-├── Closed-loop tokens                   → permissioned movement, action-request rules
-├── DeepBookV3 orderbook                 → permissionless / permissioned pools
-├── Coin standards: legacy `coin::create_currency` ⇢ newer Currency Standard via
-│   `sui::coin_registry` (new_currency / new_currency_with_otw, MetadataCap, supply states)
-│   📖 docs: .sui-docs/onchain-finance/fungible-tokens/currency.mdx
-├── Fixed-point math                     → std::fixed_point32; per-type integer modules
+│
+├── Coin<T>, Balance<T>, TreasuryCap<T> → standard open-loop currency (`key + store`: wrappable, freely transferable)
+│   📖 docs: .sui-docs/onchain-finance/fungible-tokens/index.mdx
+│   ⊃ Coin standards: legacy `coin::create_currency` ⇢ newer Currency Standard via `sui::coin_registry`
+│     (new_currency / new_currency_with_otw, MetadataCap, supply states)
+│     📖 docs: .sui-docs/onchain-finance/fungible-tokens/currency.mdx
+│
+├── Closed-loop tokens                📖 docs: .sui-docs/onchain-finance/closed-loop-token/index.mdx
+│   → `Token<T>` is `key`-only (no store): can't be wrapped, DOF-stored, or freely transferred
+│   ⊃ TokenPolicy + Rules → per-action programmable restrictions
+│     📖 docs: .sui-docs/onchain-finance/closed-loop-token/token-policy.mdx
+│   ⊃ ActionRequest → hot potato issued by protected actions (transfer/spend/to_coin/from_coin)
+│     ↔ § Authorization patterns § Hot potato   📖 docs: .sui-docs/onchain-finance/closed-loop-token/action-request.mdx
+│
+├── PAS (Permissioned Asset Standard) 📖 docs: .sui-docs/onchain-finance/pas/pas-architecture.mdx
+│   → per-address derived shared Accounts proxy ownership; every movement is a hot-potato
+│     Request that must collect approval-witness stamps per issuer Policies (TS pkg: @mysten/pas)
+│   ⇢ alternative to: Closed-loop tokens — for regulated assets needing issuer oversight
+│
+├── DeepBookV3                        📖 docs: .sui-docs/onchain-finance/deepbookv3/design.mdx
+│   → onchain CLOB; shared `Pool` (Book/State/Vault) + `PoolRegistry` + reusable `BalanceManager`
+│   ⊃ Pool types: volatile / stable / whitelisted (0-fee); fees payable in DEEP (20% cheaper than input token)
+│   ⊃ Flash loans → `FlashLoan` hot potato, repaid within the same PTB
+│     📖 docs: .sui-docs/onchain-finance/deepbookv3/contract-information/flash-loans.mdx
+│   ⊃ Margin — leveraged positions, onchain liquidation  📖 docs: .sui-docs/onchain-finance/deepbook-margin/deepbook-margin.mdx
+│   ⊃ Predict — prediction markets, oracle-driven pricing  📖 docs: .sui-docs/onchain-finance/deepbook-predict/deepbook-predict.mdx
+│
+├── Payments                          📖 docs: .sui-docs/onchain-finance/payment-kit.mdx
+│   ⊃ Payment Kit — receipts, registries, duplicate prevention, payment URIs
+│     ↔ TS SDK § payment-kit (📖 docs: .ts-sdk-docs/payment-kit/index.mdx)
+│   ⊃ Payment intents — heterogeneous payment ops batched in one atomic PTB
+│     → § Transactions § PTB structure   📖 docs: .sui-docs/onchain-finance/payment-intents.mdx
+│
+├── Fixed-point math                  → std::fixed_point32; per-type integer modules
 │   std::u8–u256 (max, diff, divide_and_round_up, sqrt, pow)
 │   📖 docs: .move-book-docs/book/move-basics/standard-library.md
+│   ↔ § Formal verification (Sui Prover) — spec-only Integer/Real types for overflow-free specs
+│
 └── ⤳ skill: oz-math (math safety audit)
    ⤳ skill: move-code-review (overflow, rounding bias, MEV exposure)
 ```
-
-Stub — flesh in v2 follow-up.
 
 ---
 


### PR DESCRIPTION
Implements the audit's improvement plan: TS SDK 2.0 rewrite, 8 stubs fleshed, 5 new topic areas (testing, events, package lifecycle, data access, formal verification), Walrus↔Seal edge. File stays ≤ 800 lines (currently 788). Evidence: knowledge-graph-audit.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Len1GGh7cpBFcoV1i7vBAG