### PR TITLE
Landing polish: contrast fixes, concrete install commands, on-model hero animation

### DIFF
--- a/site/assets/scrub-engine.js
+++ b/site/assets/scrub-engine.js
@@ -22,6 +22,7 @@
                           // (exactly where the copy peaks) and moves quicker at the
                           // edges. 0 = linear (default). Keep ≤ 0.6; 1 = full pause.
            eyebrow, title, body, tags:[…],
+           code: ['$ cmd one', '$ cmd two'],  // optional terminal-style block after body
            cta:{ primary:{label,href}, secondary:{label,href} } }, // last section only
          …
        ],
@@ -149,6 +150,7 @@ function mountScrollWorld(container, config) {
       (s.eyebrow ? `<span class="sw-copy__eyebrow">${esc(s.eyebrow)}</span>` : '') +
       (s.title ? `<h2 class="sw-copy__title">${esc(s.title)}</h2>` : '') +
       (s.body ? `<p class="sw-copy__body">${esc(s.body)}</p>` : '') +
+      (s.code && s.code.length ? `<pre class="sw-copy__code">${s.code.map(esc).join('\n')}</pre>` : '') +
       (s.tags && s.tags.length ? `<ul class="sw-copy__tags">${s.tags.map(t => `<li>${esc(t)}</li>`).join('')}</ul>` : '') +
       (s.cta ? `<div class="sw-copy__cta">${ctaBtns(s.cta)}</div>` : '');
     copylayer.appendChild(c); copies.push(c);
@@ -385,6 +387,7 @@ function injectCSS() {
   .sw-copy__eyebrow{display:block;margin-top:18px;font-family:var(--sw-font-display);font-weight:700;font-size:.8rem;letter-spacing:.16em;text-transform:uppercase;color:var(--sw-accent);}
   .sw-copy__title{font-family:var(--sw-font-display);font-weight:700;color:var(--sw-ink);font-size:clamp(2rem,4.4vw,3.5rem);line-height:1.03;margin:12px 0 0;letter-spacing:-.01em;text-shadow:0 2px 20px color-mix(in srgb,var(--sw-bg) 70%,transparent);}
   .sw-copy__body{margin-top:18px;font-size:clamp(1rem,1.25vw,1.14rem);line-height:1.55;color:color-mix(in srgb,var(--sw-ink) 78%,var(--sw-ink-soft));max-width:40ch;text-shadow:0 1px 12px color-mix(in srgb,var(--sw-bg) 90%,transparent);}
+  .sw-copy__code{margin:20px 0 0;padding:14px 18px;border-radius:12px;font-family:ui-monospace,Menlo,monospace;font-size:.86rem;line-height:1.7;color:var(--sw-ink);background:color-mix(in srgb,var(--sw-ink) 7%,var(--sw-bg));border:1px solid color-mix(in srgb,var(--sw-accent) 30%,transparent);overflow-x:auto;user-select:all;pointer-events:auto;}
   .sw-copy__tags{list-style:none;display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
   .sw-copy__tags li{font-size:.82rem;font-weight:600;color:color-mix(in srgb,var(--sw-accent) 70%,#000);padding:7px 14px;border-radius:999px;background:color-mix(in srgb,var(--sw-accent) 14%,#fff);border:1px solid color-mix(in srgb,var(--sw-accent) 30%,transparent);}
   .sw-copy__cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px;pointer-events:auto;}

--- a/site/assets/scrub-engine.js
+++ b/site/assets/scrub-engine.js
@@ -22,7 +22,7 @@
                           // (exactly where the copy peaks) and moves quicker at the
                           // edges. 0 = linear (default). Keep ≤ 0.6; 1 = full pause.
            eyebrow, title, body, tags:[…],
-           code: ['$ cmd one', '$ cmd two'],  // optional terminal-style block after body
+           code: ['$ cmd one', '$ cmd two'],  // optional terminal-style block between body and tags; one escaped line per string
            cta:{ primary:{label,href}, secondary:{label,href} } }, // last section only
          …
        ],
@@ -387,7 +387,7 @@ function injectCSS() {
   .sw-copy__eyebrow{display:block;margin-top:18px;font-family:var(--sw-font-display);font-weight:700;font-size:.8rem;letter-spacing:.16em;text-transform:uppercase;color:var(--sw-accent);}
   .sw-copy__title{font-family:var(--sw-font-display);font-weight:700;color:var(--sw-ink);font-size:clamp(2rem,4.4vw,3.5rem);line-height:1.03;margin:12px 0 0;letter-spacing:-.01em;text-shadow:0 2px 20px color-mix(in srgb,var(--sw-bg) 70%,transparent);}
   .sw-copy__body{margin-top:18px;font-size:clamp(1rem,1.25vw,1.14rem);line-height:1.55;color:color-mix(in srgb,var(--sw-ink) 78%,var(--sw-ink-soft));max-width:40ch;text-shadow:0 1px 12px color-mix(in srgb,var(--sw-bg) 90%,transparent);}
-  .sw-copy__code{margin:20px 0 0;padding:14px 18px;border-radius:12px;font-family:ui-monospace,Menlo,monospace;font-size:.86rem;line-height:1.7;color:var(--sw-ink);background:color-mix(in srgb,var(--sw-ink) 7%,var(--sw-bg));border:1px solid color-mix(in srgb,var(--sw-accent) 30%,transparent);overflow-x:auto;user-select:all;pointer-events:auto;}
+  .sw-copy__code{margin:20px 0 0;padding:14px 18px;border-radius:12px;font-family:ui-monospace,Menlo,monospace;font-size:.86rem;line-height:1.7;color:var(--sw-ink);background:color-mix(in srgb,var(--sw-ink) 7%,var(--sw-bg));border:1px solid color-mix(in srgb,var(--sw-accent) 30%,transparent);overflow-x:auto;-webkit-user-select:all;user-select:all;}
   .sw-copy__tags{list-style:none;display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 0;padding:0;}
   .sw-copy__tags li{font-size:.82rem;font-weight:600;color:color-mix(in srgb,var(--sw-accent) 70%,#000);padding:7px 14px;border-radius:999px;background:color-mix(in srgb,var(--sw-accent) 14%,#fff);border:1px solid color-mix(in srgb,var(--sw-accent) 30%,transparent);}
   .sw-copy__cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px;pointer-events:auto;}

--- a/site/index.html
+++ b/site/index.html
@@ -22,6 +22,35 @@
       --sw-font-display: "SF Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
     }
     html, body { margin: 0; background: #050805; }
+
+    /* Dark-theme contrast overrides. The engine's defaults (in @layer sw) assume a
+       light theme and hardcode #fff / white surfaces; on the abyss background that
+       leaves white-on-pale buttons and pale-on-white labels. Unlayered rules here
+       always win over the engine layer. */
+    .sw-topcta,
+    .sw-btn--primary {
+      color: #04140a;
+      background: var(--sw-accent);
+      box-shadow: 0 0 18px color-mix(in srgb, var(--sw-accent) 35%, transparent);
+    }
+    .sw-nav {
+      background: color-mix(in srgb, #050805 70%, transparent);
+      border-color: color-mix(in srgb, var(--sw-accent) 28%, transparent);
+    }
+    .sw-nav__item.is-active { color: #04140a; }
+    .sw-route__label {
+      color: var(--sw-ink);
+      background: color-mix(in srgb, #050805 88%, transparent);
+      border-color: color-mix(in srgb, var(--sw-accent) 40%, transparent);
+    }
+    .sw-copy__tags li {
+      color: color-mix(in srgb, var(--sw-accent) 88%, #fff);
+      background: color-mix(in srgb, var(--sw-accent) 12%, #050805);
+      border-color: color-mix(in srgb, var(--sw-accent) 45%, transparent);
+    }
+    .sw-btn--ghost {
+      border-color: color-mix(in srgb, var(--sw-accent) 55%, transparent);
+    }
   </style>
 </head>
 <body>
@@ -53,7 +82,7 @@
           scroll: 1.5, linger: 0.35,
           eyebrow: 'A Claude Code plugin',
           title: 'Follow the whale.',
-          body: 'sui-pilot turns Claude into a Sui/Move expert — grounded in current docs, not stale training data.',
+          body: 'sui-pilot is an open-source Claude Code plugin that turns Claude into a Sui/Move expert — answers grounded in current docs, not stale training data.',
           tags: ['766 docs', 'Move LSP', 'Sui Prover'],
         },
         {
@@ -75,7 +104,7 @@
           scroll: 1.35, linger: 0.4,
           eyebrow: 'Real-time diagnostics',
           title: 'Code that checks itself.',
-          body: 'A Move LSP bridge gives Claude live diagnostics, hover types, references and completions while it writes your Move code.',
+          body: 'A move-analyzer LSP bridge gives Claude live diagnostics, hover types, references and completions while it writes your Move code — errors surface as it types, not after you compile.',
           tags: ['move-analyzer', '10 LSP tools', 'MCP'],
         },
         {
@@ -97,11 +126,15 @@
           scroll: 1.8, linger: 0.5,
           eyebrow: 'Free your code',
           title: 'Plug in.',
-          body: 'Two commands in Claude Code, and every Sui/Move answer is doc-grounded, LSP-checked and provable.',
+          body: 'Two commands in Claude Code, then restart — every Sui/Move answer becomes doc-grounded, LSP-checked and provable.',
+          code: [
+            '/plugin marketplace add contract-hero/plugin-marketplace',
+            '/plugin install sui-pilot@contract-hero',
+          ],
           tags: ['/move-code-review', '/move-code-quality', '/oz-math'],
           cta: {
-            primary:   { label: 'Get started on GitHub', href: 'https://github.com/contract-hero/sui-pilot' },
-            secondary: { label: 'Read the full story',   href: 'classic.html' },
+            primary:   { label: 'Install guide on GitHub', href: 'https://github.com/contract-hero/sui-pilot#install' },
+            secondary: { label: 'Read the full story',     href: 'classic.html' },
           },
         },
       ],

--- a/site/index.html
+++ b/site/index.html
@@ -19,6 +19,7 @@
       --sw-ink: #eaf6ec;
       --sw-ink-soft: #8fae97;
       --sw-accent: #39ff6a;      /* neon matrix green */
+      --sw-on-accent: #04140a;   /* ink for text sitting on the accent */
       --sw-font-display: "SF Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
     }
     html, body { margin: 0; background: #050805; }
@@ -29,23 +30,23 @@
        always win over the engine layer. */
     .sw-topcta,
     .sw-btn--primary {
-      color: #04140a;
+      color: var(--sw-on-accent);
       background: var(--sw-accent);
       box-shadow: 0 0 18px color-mix(in srgb, var(--sw-accent) 35%, transparent);
     }
     .sw-nav {
-      background: color-mix(in srgb, #050805 70%, transparent);
+      background: color-mix(in srgb, var(--sw-bg) 70%, transparent);
       border-color: color-mix(in srgb, var(--sw-accent) 28%, transparent);
     }
-    .sw-nav__item.is-active { color: #04140a; }
+    .sw-nav__item.is-active { color: var(--sw-on-accent); }
     .sw-route__label {
       color: var(--sw-ink);
-      background: color-mix(in srgb, #050805 88%, transparent);
+      background: color-mix(in srgb, var(--sw-bg) 88%, transparent);
       border-color: color-mix(in srgb, var(--sw-accent) 40%, transparent);
     }
     .sw-copy__tags li {
       color: color-mix(in srgb, var(--sw-accent) 88%, #fff);
-      background: color-mix(in srgb, var(--sw-accent) 12%, #050805);
+      background: color-mix(in srgb, var(--sw-accent) 12%, var(--sw-bg));
       border-color: color-mix(in srgb, var(--sw-accent) 45%, transparent);
     }
     .sw-btn--ghost {


### PR DESCRIPTION
## Summary
- **Contrast**: the vendored scroll-world engine's CSS assumes a light theme (hardcoded `#fff` text/surfaces), which made the top CTA and primary button near-invisible on the dark Matrix theme. Unlayered overrides in `index.html` now give every interactive element WCAG-AAA contrast (buttons 14:1, tag pills ~12:1, route labels/code block ~18:1).
- **Meaningful copy**: the final section shows the actual install commands in a new terminal-style `code:` block (small vendored-engine extension), and the primary CTA deep-links to the README `#install` section. Hero + LSP section bodies got more concrete context. Doc counts still match `llms.txt` (766 / 374 / 143 / 121).
- **Hero animation**: `leg0.mp4` regenerated — the old clip drifted off-model (elongated snout, deformed mouth) once the whale started swimming. New pipeline: Nano Banana angle shots from the exact first frame as reference, then two 5s kling3_0 segments anchored first-frame → on-model banked pose → last frame, joined with a 0.25s crossfade. The mascot stays chubby and on-model for the full 9.75s, and the ending still lands on leg1's opening pose so the scroll chain stays seamless.

## Test plan
- [x] `cd site && python3 -m http.server` → scroll the full flight; verify button/label legibility at every section
- [x] Verify the install-commands block renders and is selectable in the final section
- [x] Scrub the hero section and confirm the whale stays on-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)